### PR TITLE
[ デザイン仕様変更 ] 見出しの下の余白指定削除

### DIFF
--- a/assets/_scss/_common_margin-vertical.scss
+++ b/assets/_scss/_common_margin-vertical.scss
@@ -23,8 +23,6 @@ p{
 	&,
 	body :is( .wp-site-blocks, .is-layout-constrained, .is-layout-flow ) > * + &{
 		margin-block-start:1.5em;
-		// 意図する余白 - この要素の下側のレディング
-		margin-block-end: calc( var(--wp--custom--spacing--small) - (  1em - 1em * var(--wp--custom--typography--line-height--heading) ) / 2 );
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Tuning ] Delete heading margin bottom
+
 1.3.4
 [ Bug fix ] Fix custom HTML block iframe preview don't display on editor screen.
 


### PR DESCRIPTION
おそらく見出しの下の余白について、spacing から レディング分引いた値に指定してあったが、
見出しの文字サイズが大きかったりする事から結局その方が余白が大きくなりすぎたりするため削除