### PR TITLE
【確認待ち】[ ナビゲーションブロック ] 子階層メニューのページを表示している時、親メニューへのスタイリングを追加

### DIFF
--- a/assets/_scss/_navigation_additional-class.scss
+++ b/assets/_scss/_navigation_additional-class.scss
@@ -5,50 +5,45 @@
 @use 'variables' as var;
 
 .nav--open--lg-up {
-  @media (min-width: var.$lg-min) {
-    // 閉じるボタンを非表示にする
-    // Change to hidden close button
-    .wp-block-navigation__responsive-container:not(.hidden-by-default):not(
-        .is-menu-open
-      )
-      .wp-block-navigation__responsive-container-close {
-      display: none;
-    }
+	@media (min-width: var.$lg-min) {
 
-    // メニュー部分を表示にする
-    // Change to display navigation
-    .wp-block-navigation__responsive-container:not(.hidden-by-default):not(
-        .is-menu-open
-      ) {
-      display: block;
-      // Default propaties
-      // width: 100%;
-      // position: relative;
-      // z-index: auto;
-      // background-color: inherit;
-    }
-  }
+		// 閉じるボタンを非表示にする
+		// Change to hidden close button
+		.wp-block-navigation__responsive-container:not(.hidden-by-default):not(.is-menu-open) .wp-block-navigation__responsive-container-close {
+			display: none;
+		}
 
-  @media (max-width: var.$md-max) {
-    // 閉じるボタンを表示にする
-    // Change to display close button
-    .wp-block-navigation__responsive-container-open:not(.always-shown) {
-      display: block;
-    }
+		// メニュー部分を表示にする
+		// Change to display navigation
+		.wp-block-navigation__responsive-container:not(.hidden-by-default):not(.is-menu-open) {
+			display: block;
+			// Default propaties
+			// width: 100%;
+			// position: relative;
+			// z-index: auto;
+			// background-color: inherit;
+		}
+	}
 
-    // メニュー部分を非表示にする
-    // Change to hidden navigation
-    .wp-block-navigation__responsive-container:not(.hidden-by-default):not(
-        .is-menu-open
-      ) {
-      display: none;
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-    }
-  }
+	@media (max-width: var.$md-max) {
+
+		// 閉じるボタンを表示にする
+		// Change to display close button
+		.wp-block-navigation__responsive-container-open:not(.always-shown) {
+			display: block;
+		}
+
+		// メニュー部分を非表示にする
+		// Change to hidden navigation
+		.wp-block-navigation__responsive-container:not(.hidden-by-default):not(.is-menu-open) {
+			display: none;
+			position: fixed;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+		}
+	}
 }
 
 /******************************************************
@@ -56,33 +51,33 @@
  */
 
 *[class*='nav--active-border-bottom'] {
-  .wp-block-navigation__responsive-container:where(:not(.is-menu-open)) {
-    :where(.wp-block-navigation__container, .wp-block-page-list) {
-      & > .wp-block-navigation-item {
-        & > a {
-          padding-top: 1em;
-          padding-bottom: 1em;
-        }
+	.wp-block-navigation__responsive-container:where(:not(.is-menu-open)) {
+		:where(.wp-block-navigation__container, .wp-block-page-list) {
+			&>.wp-block-navigation-item {
+				&>a {
+					padding-top: 1em;
+					padding-bottom: 1em;
+				}
 
-        & > a::after {
-          transition: all 0.2s ease-out;
-          width: 0%;
-          content: '';
-          display: block;
-          bottom: 0;
-          left: 0;
-          position: absolute;
-          border-bottom: 2px solid var(--wp--preset--color--primary);
-        }
+				&>a::after {
+					transition: all 0.2s ease-out;
+					width: 0%;
+					content: '';
+					display: block;
+					bottom: 0;
+					left: 0;
+					position: absolute;
+					border-bottom: 2px solid var(--wp--preset--color--primary);
+				}
 
-        & > :is(a:hover, .current-menu-item > a, .current-menu-ancestor) {
-          &::after {
-            width: 100%;
-          }
-        }
-      }
-    }
-  }
+				&> :is(a:hover, .current-menu-item > a, .current-menu-ancestor) {
+					&::after {
+						width: 100%;
+					}
+				}
+			}
+		}
+	}
 }
 
 /******************************************************
@@ -95,96 +90,100 @@
 
  */
 *[class*='nav--text-inline'] {
-  --nav--text-inline--border: var(--wp--preset--color--border-normal);
-  // border:1px solid #ff0000 !important;
-  &.nav--darkbg {
-    --nav--text-inline--border: var(--wp--preset--color--border-normal-darkbg);
-  }
-  &
-    > :is(
-      .wp-block-navigation__container,
-      .wp-block-navigation__responsive-container
-    ) {
-    .wp-block-navigation-item {
-      border-left: 1px solid var(--nav--text-inline--border);
-    }
-    &.is-menu-open {
-      .wp-block-navigation-item {
-        border-left: none;
-        border-right: none;
-      }
-    }
-  }
+	--nav--text-inline--border: var(--wp--preset--color--border-normal);
 
-  :where(.wp-block-navigation__container, .wp-block-page-list) {
-    // gap: 0;
+	// border:1px solid #ff0000 !important;
+	&.nav--darkbg {
+		--nav--text-inline--border: var(--wp--preset--color--border-normal-darkbg);
+	}
 
-    & > .wp-block-navigation-item {
-      &:last-child {
-        border-right: 1px solid var(--nav--text-inline--border);
-      }
+	&> :is(.wp-block-navigation__container,
+		.wp-block-navigation__responsive-container) {
+		.wp-block-navigation-item {
+			border-left: 1px solid var(--nav--text-inline--border);
+		}
 
-      & > a {
-        &:hover {
-          text-decoration: underline;
-        }
-      }
-    }
-  }
-  // Dusable sub menu and icon
-  .wp-block-navigation__submenu-icon,
-  & .has-child .wp-block-navigation__submenu-container {
-    display: none;
-  }
-  // Modal
-  & > .wp-block-navigation__responsive-container {
-    &.is-menu-open {
-      .wp-block-navigation-item {
-        border-left: none;
-        &:last-child {
-          border-right: none;
-        }
-      }
-    }
-  }
+		&.is-menu-open {
+			.wp-block-navigation-item {
+				border-left: none;
+				border-right: none;
+			}
+		}
+	}
+
+	:where(.wp-block-navigation__container, .wp-block-page-list) {
+		// gap: 0;
+
+		&>.wp-block-navigation-item {
+			&:last-child {
+				border-right: 1px solid var(--nav--text-inline--border);
+			}
+
+			&>a {
+				&:hover {
+					text-decoration: underline;
+				}
+			}
+		}
+	}
+
+	// Dusable sub menu and icon
+	.wp-block-navigation__submenu-icon,
+	& .has-child .wp-block-navigation__submenu-container {
+		display: none;
+	}
+
+	// Modal
+	&>.wp-block-navigation__responsive-container {
+		&.is-menu-open {
+			.wp-block-navigation-item {
+				border-left: none;
+
+				&:last-child {
+					border-right: none;
+				}
+			}
+		}
+	}
 }
 
 /******************************************************
  * Vertical with hr
  */
 *[class*='nav--vertical-with-hr'] {
-  --wp--custom--spacing--menu-indent: 0.8em;
+	--wp--custom--spacing--menu-indent: 0.8em;
 
-  .wp-block-navigation-item {
-    margin: 0;
+	.wp-block-navigation-item {
+		margin: 0;
 
-    & > .wp-block-navigation-item__content,
-    & > a.wp-block-navigation-item__content {
-      padding: 0.8em;
-      border-bottom: 1px solid var(--wp--preset--color--border-normal);
-    }
+		&>.wp-block-navigation-item__content,
+		&>a.wp-block-navigation-item__content {
+			padding: 0.8em;
+			border-bottom: 1px solid var(--wp--preset--color--border-normal);
+		}
 
-    &.has-text-normal-darkbg-color {
-      & > .wp-block-navigation-item__content,
-      & > a.wp-block-navigation-item__content {
-        border-bottom: 1px solid var(--wp--preset--color--border-normal-darkbg);
-      }
-    }
+		&.has-text-normal-darkbg-color {
 
-    .wp-block-navigation__submenu-container {
-      display: block;
-      height: auto;
-      width: 100%;
+			&>.wp-block-navigation-item__content,
+			&>a.wp-block-navigation-item__content {
+				border-bottom: 1px solid var(--wp--preset--color--border-normal-darkbg);
+			}
+		}
 
-      .wp-block-navigation-item {
-        .wp-block-navigation-item__content {
-          padding-left: calc(var(--wp--custom--spacing--menu-indent) * 2);
-        }
+		.wp-block-navigation__submenu-container {
+			display: block;
+			height: auto;
+			width: 100%;
 
-        .wp-block-navigation-item .wp-block-navigation-item__content {
-          padding-left: calc(var(--wp--custom--spacing--menu-indent) * 3);
-        }
-      }
-    }
-  }
+			.wp-block-navigation-item {
+				.wp-block-navigation-item__content {
+					padding-left: calc(var(--wp--custom--spacing--menu-indent) * 2);
+				}
+
+				.wp-block-navigation-item .wp-block-navigation-item__content {
+					padding-left: calc(var(--wp--custom--spacing--menu-indent) * 3);
+				}
+			}
+		}
+	}
 }

--- a/assets/_scss/_navigation_additional-class.scss
+++ b/assets/_scss/_navigation_additional-class.scss
@@ -1,182 +1,190 @@
-/* 
+/*
  * Navigation Additonal class
  */
 
-@use "variables" as var;
+@use 'variables' as var;
 
 .nav--open--lg-up {
-	@media (min-width: var.$lg-min) {
+  @media (min-width: var.$lg-min) {
+    // 閉じるボタンを非表示にする
+    // Change to hidden close button
+    .wp-block-navigation__responsive-container:not(.hidden-by-default):not(
+        .is-menu-open
+      )
+      .wp-block-navigation__responsive-container-close {
+      display: none;
+    }
 
-		// 閉じるボタンを非表示にする
-		// Change to hidden close button
-		.wp-block-navigation__responsive-container:not(.hidden-by-default):not(.is-menu-open) .wp-block-navigation__responsive-container-close {
-			display: none;
-		}
+    // メニュー部分を表示にする
+    // Change to display navigation
+    .wp-block-navigation__responsive-container:not(.hidden-by-default):not(
+        .is-menu-open
+      ) {
+      display: block;
+      // Default propaties
+      // width: 100%;
+      // position: relative;
+      // z-index: auto;
+      // background-color: inherit;
+    }
+  }
 
-		// メニュー部分を表示にする
-		// Change to display navigation
-		.wp-block-navigation__responsive-container:not(.hidden-by-default):not(.is-menu-open) {
-			display: block;
-			// Default propaties
-			// width: 100%;
-			// position: relative;
-			// z-index: auto;
-			// background-color: inherit;
-		}
-	}
+  @media (max-width: var.$md-max) {
+    // 閉じるボタンを表示にする
+    // Change to display close button
+    .wp-block-navigation__responsive-container-open:not(.always-shown) {
+      display: block;
+    }
 
-	@media (max-width: var.$md-max) {
-
-		// 閉じるボタンを表示にする
-		// Change to display close button
-		.wp-block-navigation__responsive-container-open:not(.always-shown) {
-			display: block;
-		}
-
-		// メニュー部分を非表示にする
-		// Change to hidden navigation
-		.wp-block-navigation__responsive-container:not(.hidden-by-default):not(.is-menu-open) {
-			display: none;
-			position: fixed;
-			top: 0;
-			left: 0;
-			right: 0;
-			bottom: 0;
-		}
-	}
+    // メニュー部分を非表示にする
+    // Change to hidden navigation
+    .wp-block-navigation__responsive-container:not(.hidden-by-default):not(
+        .is-menu-open
+      ) {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+    }
+  }
 }
 
-/****************************************************** 
+/******************************************************
  * active-border-bottom
  */
 
-*[class*="nav--active-border-bottom"] {
-	.wp-block-navigation__responsive-container:where(:not(.is-menu-open)) {
-		:where(.wp-block-navigation__container, .wp-block-page-list) {
-			&>.wp-block-navigation-item {
-				&>a {
-					padding-top: 1em;
-					padding-bottom: 1em;
-				}
+*[class*='nav--active-border-bottom'] {
+  .wp-block-navigation__responsive-container:where(:not(.is-menu-open)) {
+    :where(.wp-block-navigation__container, .wp-block-page-list) {
+      & > .wp-block-navigation-item {
+        & > a {
+          padding-top: 1em;
+          padding-bottom: 1em;
+        }
 
-				&>a::after {
-					transition: all 0.2s ease-out;
-					width: 0%;
-					content: "";
-					display: block;
-					bottom: 0;
-					left: 0;
-					position: absolute;
-					border-bottom: 2px solid var(--wp--preset--color--primary);
-				}
+        & > a::after {
+          transition: all 0.2s ease-out;
+          width: 0%;
+          content: '';
+          display: block;
+          bottom: 0;
+          left: 0;
+          position: absolute;
+          border-bottom: 2px solid var(--wp--preset--color--primary);
+        }
 
-				&> :is(a:hover, .current-menu-item > a) {
-					&::after {
-						width: 100%;
-					}
-				}
-			}
-		}
-	}
+        & > :is(a:hover, .current-menu-item > a, .current-menu-ancestor) {
+          &::after {
+            width: 100%;
+          }
+        }
+      }
+    }
+  }
 }
 
-/****************************************************** 
+/******************************************************
  * Text inline
  is-style-nav--text-inline
 
-	nav.wp-block-navigation.is-style-nav--text-inline 
+	nav.wp-block-navigation.is-style-nav--text-inline
 	> .wp-block-navigation__responsive-container.is-menu-open.has-modal-open
 	. wp-block-navigation__container
 
  */
-*[class*="nav--text-inline"] {
-	--nav--text-inline--border: var(--wp--preset--color--border-normal);
-	// border:1px solid #ff0000 !important;
-	&.nav--darkbg {
-		--nav--text-inline--border: var(--wp--preset--color--border-normal-darkbg);
-	}
-	& > :is(.wp-block-navigation__container,.wp-block-navigation__responsive-container) {
-		.wp-block-navigation-item {
-			border-left: 1px solid var(--nav--text-inline--border);
-		}
-		&.is-menu-open {
-			.wp-block-navigation-item {
-				border-left: none;
-				border-right: none;
-			}
-		}
-	}
+*[class*='nav--text-inline'] {
+  --nav--text-inline--border: var(--wp--preset--color--border-normal);
+  // border:1px solid #ff0000 !important;
+  &.nav--darkbg {
+    --nav--text-inline--border: var(--wp--preset--color--border-normal-darkbg);
+  }
+  &
+    > :is(
+      .wp-block-navigation__container,
+      .wp-block-navigation__responsive-container
+    ) {
+    .wp-block-navigation-item {
+      border-left: 1px solid var(--nav--text-inline--border);
+    }
+    &.is-menu-open {
+      .wp-block-navigation-item {
+        border-left: none;
+        border-right: none;
+      }
+    }
+  }
 
-	:where(.wp-block-navigation__container, .wp-block-page-list) {
-		// gap: 0;
+  :where(.wp-block-navigation__container, .wp-block-page-list) {
+    // gap: 0;
 
-		&>.wp-block-navigation-item {
+    & > .wp-block-navigation-item {
+      &:last-child {
+        border-right: 1px solid var(--nav--text-inline--border);
+      }
 
-			&:last-child {
-				border-right: 1px solid var(--nav--text-inline--border);
-			}
-
-			&>a {
-				&:hover {
-					text-decoration: underline;
-				}
-			}
-		}
-	}
-	// Dusable sub menu and icon
-	.wp-block-navigation__submenu-icon,
-	& .has-child .wp-block-navigation__submenu-container {
-		display: none;
-	}
-	// Modal
-	& > .wp-block-navigation__responsive-container {
-		&.is-menu-open {
-			.wp-block-navigation-item {
-				border-left: none;
-				&:last-child {
-					border-right: none;
-				}
-			}
-		}
-	}
+      & > a {
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+  // Dusable sub menu and icon
+  .wp-block-navigation__submenu-icon,
+  & .has-child .wp-block-navigation__submenu-container {
+    display: none;
+  }
+  // Modal
+  & > .wp-block-navigation__responsive-container {
+    &.is-menu-open {
+      .wp-block-navigation-item {
+        border-left: none;
+        &:last-child {
+          border-right: none;
+        }
+      }
+    }
+  }
 }
 
-/****************************************************** 
+/******************************************************
  * Vertical with hr
  */
-*[class*="nav--vertical-with-hr"] {
-	--wp--custom--spacing--menu-indent: 0.8em;
+*[class*='nav--vertical-with-hr'] {
+  --wp--custom--spacing--menu-indent: 0.8em;
 
-	.wp-block-navigation-item {
-		margin: 0;
+  .wp-block-navigation-item {
+    margin: 0;
 
-		&>.wp-block-navigation-item__content,
-		&>a.wp-block-navigation-item__content {
-			padding: 0.8em;
-			border-bottom: 1px solid var(--wp--preset--color--border-normal);
-		}
+    & > .wp-block-navigation-item__content,
+    & > a.wp-block-navigation-item__content {
+      padding: 0.8em;
+      border-bottom: 1px solid var(--wp--preset--color--border-normal);
+    }
 
-		&.has-text-normal-darkbg-color {
-			&>.wp-block-navigation-item__content,
-			&>a.wp-block-navigation-item__content {
-				border-bottom: 1px solid var(--wp--preset--color--border-normal-darkbg);
-			}
-		}
+    &.has-text-normal-darkbg-color {
+      & > .wp-block-navigation-item__content,
+      & > a.wp-block-navigation-item__content {
+        border-bottom: 1px solid var(--wp--preset--color--border-normal-darkbg);
+      }
+    }
 
-		.wp-block-navigation__submenu-container {
-			display: block;
-			height: auto;
-			width: 100%;
+    .wp-block-navigation__submenu-container {
+      display: block;
+      height: auto;
+      width: 100%;
 
-			.wp-block-navigation-item {
-				.wp-block-navigation-item__content {
-					padding-left: calc(var(--wp--custom--spacing--menu-indent) * 2);
-				}
+      .wp-block-navigation-item {
+        .wp-block-navigation-item__content {
+          padding-left: calc(var(--wp--custom--spacing--menu-indent) * 2);
+        }
 
-				.wp-block-navigation-item .wp-block-navigation-item__content {
-					padding-left: calc(var(--wp--custom--spacing--menu-indent) * 3);
-				}
-			}
-		}
-	}
+        .wp-block-navigation-item .wp-block-navigation-item__content {
+          padding-left: calc(var(--wp--custom--spacing--menu-indent) * 3);
+        }
+      }
+    }
+  }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Tuning ] Add styles when displaying child level menu pages in the navigation block.
+
 1.11.0
 [ Add ] Add Search Result Template
 [ Design Tuning ] Add styles to inline code block.


### PR DESCRIPTION
https://github.com/vektor-inc/x-t9/issues/27

ナビゲーションブロックの子階層メニューのページを表示している時、親メニューへのスタイルを追加しました。

<img width="1128" alt="スクリーンショット 2023-04-20 14 12 54" src="https://user-images.githubusercontent.com/73574599/233264470-24c2466f-383e-436b-9d04-46fa6aa6d731.png">

<img width="1165" alt="スクリーンショット 2023-04-20 14 12 46" src="https://user-images.githubusercontent.com/73574599/233264463-9c80dc43-ae04-416c-97db-9fe4c227d915.png">
