### PR TITLE
 [アクセシビリティ対応] 続きを読む

### DIFF
--- a/assets/_scss/_block.scss
+++ b/assets/_scss/_block.scss
@@ -2,7 +2,8 @@
  * Core block styles overrides
  */
 
-.wp-block-post-excerpt__more-text {
+.wp-block-post-excerpt__more-text,
+.wp-block-read-more {
 	margin-block-start: var(--wp--custom--spacing--small);
 }
 

--- a/assets/_scss/_button.scss
+++ b/assets/_scss/_button.scss
@@ -6,6 +6,7 @@
 .wp-block-button__link,
 .wp-block-search__button,
 .wp-block-post-excerpt__more-link,
+.wp-block-read-more,
 .wp-block-button__link.has-primary-background-color {
 	transition: all 0.1s ease-in;
 	background-color: var(--wp--preset--color--primary);

--- a/assets/_scss/_query.scss
+++ b/assets/_scss/_query.scss
@@ -55,10 +55,9 @@
 		}
 	}
 
-	.wp-block-post-excerpt__more-text {
-		a {
-			font-size: var(--wp--preset--font-size--small);
-			padding: var(--wp--custom--spacing--button-sm);
-		}
+	.wp-block-post-excerpt__more-text a,
+	a.wp-block-read-more {
+		font-size: var(--wp--preset--font-size--small);
+		padding: var(--wp--custom--spacing--button-sm);
 	}
 }

--- a/inc/patterns/featured/featured-columns-menu.php
+++ b/inc/patterns/featured/featured-columns-menu.php
@@ -9,8 +9,8 @@ return array(
 	'title'      => __( 'Columns Menu Section', 'x-t9' ),
 	'categories' => array( 'featured', 'pr-contents' ),
 	'content'    => '<!-- wp:cover {"url":"' . esc_url( get_template_directory_uri() ) . '/inc/patterns/images/sample-image-gray.png","hasParallax":true,"dimRatio":90,"overlayColor":"bg-primary","minHeight":250,"contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
-	<div class="wp-block-cover alignfull is-light has-parallax" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;min-height:250px"><span aria-hidden="true" class="wp-block-cover__background has-bg-primary-background-color has-background-dim-90 has-background-dim"></span><div role="img" class="wp-block-cover__image-background has-parallax" style="background-position:50% 50%;background-image:url(' . esc_url( get_template_directory_uri() ) . '/inc/patterns/images/sample-image-gray.png)"></div><div class="wp-block-cover__inner-container"><!-- wp:spacer {"height":"","className":"is-style-spacer-lg"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+	<div class="wp-block-cover alignfull is-light has-parallax" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;min-height:250px"><span aria-hidden="true" class="wp-block-cover__background has-bg-primary-background-color has-background-dim-90 has-background-dim"></span><div role="img" class="wp-block-cover__image-background has-parallax" style="background-position:50% 50%;background-image:url(' . esc_url( get_template_directory_uri() ) . '/inc/patterns/images/sample-image-gray.png)"></div><div class="wp-block-cover__inner-container"><!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 	<!-- /wp:spacer -->
 	
 	<!-- wp:group {"layout":{"type":"constrained"}} -->

--- a/inc/patterns/featured/featured-post-list.php
+++ b/inc/patterns/featured/featured-post-list.php
@@ -45,7 +45,7 @@ return array(
 	<!-- wp:post-terms {"term":"category","prefix":"' . esc_html__( 'Category : ', 'x-t9' ) . '"} /--></div>
 	<!-- /wp:group -->
 	
-	<!-- wp:post-excerpt {"moreText":"' . esc_html__( 'Read more', 'x-t9' ) . '","style":{"spacing":{"margin":{"top":"var:preset|spacing|40","right":"0","bottom":"0","left":"0"}}}} /--></div>
+	<!-- wp:post-excerpt {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","right":"0","bottom":"0","left":"0"}}}} /--><!-- wp:read-more /--></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->
 	

--- a/inc/patterns/post-template-image-left.php
+++ b/inc/patterns/post-template-image-left.php
@@ -22,7 +22,7 @@ return array(
 	<!-- wp:post-terms {"term":"category","prefix":"' . esc_html__( 'Category : ', 'x-t9' ) . '"} /--></div>
 	<!-- /wp:group -->
 	
-	<!-- wp:post-excerpt {"moreText":"' . esc_html__( 'Read more', 'x-t9' ) . '","style":{"spacing":{"margin":{"top":"var:preset|spacing|40","right":"0","bottom":"0","left":"0"}}}} /--></div>
+	<!-- wp:post-excerpt {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","right":"0","bottom":"0","left":"0"}}}} /--><!-- wp:read-more  /--></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->
 	

--- a/inc/patterns/query-image-left.php
+++ b/inc/patterns/query-image-left.php
@@ -31,7 +31,7 @@ return array(
 	<!-- wp:post-terms {"term":"category","prefix":"' . esc_html__( 'Category : ', 'x-t9' ) . '"} /--></div>
 	<!-- /wp:group -->
 	
-	<!-- wp:post-excerpt {"moreText":"' . esc_html__( 'Read more', 'x-t9' ) . '","style":{"spacing":{"margin":{"top":"var:preset|spacing|40","right":"0","bottom":"0","left":"0"}}}} /--></div>
+	<!-- wp:post-excerpt {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","right":"0","bottom":"0","left":"0"}}}} /--><!-- wp:read-more /--></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns -->
 	

--- a/inc/patterns/query-image-left.php
+++ b/inc/patterns/query-image-left.php
@@ -41,7 +41,7 @@ return array(
 	<!-- /wp:post-template -->
 
 	<!-- wp:spacer {"height":"","className":"is-style-spacer-md"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
 	<!-- /wp:spacer -->
 	
 	<!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center","orientation":"horizontal","flexWrap":"wrap"}} -->
@@ -52,8 +52,8 @@ return array(
 	<!-- wp:query-pagination-next {"label":"' . esc_html__( 'Next', 'x-t9' ) . '"} /-->
 	<!-- /wp:query-pagination -->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-md"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-md"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
 	<!-- /wp:spacer -->
 
 	</div>

--- a/inc/patterns/query-image-left.php
+++ b/inc/patterns/query-image-left.php
@@ -40,7 +40,7 @@ return array(
 	<!-- /wp:separator -->
 	<!-- /wp:post-template -->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-md"} -->
+	<!-- wp:spacer {"className":"is-style-spacer-md"} -->
 	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
 	<!-- /wp:spacer -->
 	

--- a/parts/loop-archive.html
+++ b/parts/loop-archive.html
@@ -9,8 +9,8 @@
 	<!-- wp:pattern {"slug":"x-t9/post-template-image-left"} /-->
 	<!-- /wp:post-template -->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-md"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-md"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
 	<!-- /wp:spacer -->
 
 	<!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center","orientation":"horizontal","flexWrap":"wrap"}} -->

--- a/parts/page-header-single.html
+++ b/parts/page-header-single.html
@@ -4,8 +4,8 @@
 	<span aria-hidden="true"
 		class="wp-block-cover__background has-bg-secondary-background-color has-background-dim-100 has-background-dim"></span>
 	<div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained"}} -->
-		<div class="wp-block-group"><!-- wp:spacer {"height":"","className":"is-style-spacer-md"} -->
-			<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+		<div class="wp-block-group"><!-- wp:spacer {"className":"is-style-spacer-md"} -->
+			<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
 			<!-- /wp:spacer -->
 
 			<!-- wp:post-title {"textAlign":"center","level":1,"style":{"spacing":{"margin":{"bottom":"0"}}},"textColor":"text-normal"} /-->
@@ -19,8 +19,8 @@
 			</div>
 			<!-- /wp:group -->
 
-			<!-- wp:spacer {"height":"","className":"is-style-spacer-md"} -->
-			<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+			<!-- wp:spacer {"className":"is-style-spacer-md"} -->
+			<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
 			<!-- /wp:spacer -->
 		</div>
 		<!-- /wp:group -->

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: kurudrive,vektor-inc
 Tested up to: 6.2
 Requires PHP: 7.2
-Stable tag: 1.16.8
+Stable tag: 1.17.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+1.17.0
 [ Specification Change ] Deactive typography fruid
 [ Design Tuning ] Delete underline from post term block
 [ Design Tuning ][ Header pattern ] Logo --- Nav --- Contact

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: kurudrive,vektor-inc
 Tested up to: 6.2
 Requires PHP: 7.2
-Stable tag: 1.16.6
+Stable tag: 1.16.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,6 +12,9 @@ The X-T9 is designed on the premise of full site editing function, and the user 
 GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
+
+1.16.7
+[ Bug fix ] Fix Pattern recovery
 
 1.16.6
 [ Design Tuning ] Delete VK Breadcrumb top margin

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: kurudrive,vektor-inc
 Tested up to: 6.2
 Requires PHP: 7.2
-Stable tag: 1.16.7
+Stable tag: 1.16.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -13,8 +13,11 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+1.16.8
+[ Bug fix ] Fix spacer block recovery ( Template )
+
 1.16.7
-[ Bug fix ] Fix Pattern recovery
+[ Bug fix ] Fix spacer block recovery ( Pattern )
 
 1.16.6
 [ Design Tuning ] Delete VK Breadcrumb top margin

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: kurudrive,vektor-inc
 Tested up to: 6.2
 Requires PHP: 7.2
-Stable tag: 1.17.0
+Stable tag: 1.17.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,6 +12,9 @@ The X-T9 is designed on the premise of full site editing function, and the user 
 GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
+
+1.17.1
+[ Bug fix ] Fix font size x-small
 
 1.17.0
 [ Specification Change ] Deactive typography fruid

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: kurudrive,vektor-inc
 Tested up to: 6.2
 Requires PHP: 7.2
-Stable tag: 1.16.3
+Stable tag: 1.16.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+1.16.4
 [ Design Bug fix ] Fix(reset) navigation block gap on edit screen
 
 1.16.3

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: The X-T9 is designed on the premise of full site editing function, 
 Requires at least: 6.1
 Tested up to: 6.2
 Requires PHP: 7.2
-Version: 1.16.6
+Version: 1.16.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: x-t9

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: The X-T9 is designed on the premise of full site editing function, 
 Requires at least: 6.1
 Tested up to: 6.2
 Requires PHP: 7.2
-Version: 1.16.3
+Version: 1.16.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: x-t9

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: The X-T9 is designed on the premise of full site editing function, 
 Requires at least: 6.1
 Tested up to: 6.2
 Requires PHP: 7.2
-Version: 1.16.7
+Version: 1.16.8
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: x-t9

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: The X-T9 is designed on the premise of full site editing function, 
 Requires at least: 6.1
 Tested up to: 6.2
 Requires PHP: 7.2
-Version: 1.17.0
+Version: 1.17.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: x-t9

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: The X-T9 is designed on the premise of full site editing function, 
 Requires at least: 6.1
 Tested up to: 6.2
 Requires PHP: 7.2
-Version: 1.16.8
+Version: 1.17.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: x-t9

--- a/templates/front-page.html
+++ b/templates/front-page.html
@@ -6,14 +6,14 @@
 	<!-- wp:pattern {"slug":"x-t9/featured/featured-columns-menu"} /-->
 	<!-- wp:pattern {"slug":"x-t9/featured/featured-post-list"} /-->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-lg"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 	<!-- /wp:spacer -->
 
 	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-lg"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 	<!-- /wp:spacer -->
 
 </main>

--- a/templates/home.html
+++ b/templates/home.html
@@ -29,8 +29,8 @@
 		class="wp-block-separator alignfull has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide" />
 	<!-- /wp:separator -->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-lg"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 	<!-- /wp:spacer -->
 
 	<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|70","left":"var:preset|spacing|70"}}},"className":"is-style-main-layout"} -->
@@ -48,8 +48,8 @@
 		<!-- /wp:column -->
 	</div>
 	<!-- /wp:columns -->
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-xl"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-xl"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
 	<!-- /wp:spacer -->
 </main>
 <!-- /wp:group -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,8 +28,8 @@
 		class="wp-block-separator alignfull has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide" />
 	<!-- /wp:separator -->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-lg"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 	<!-- /wp:spacer -->
 
 	<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|70","left":"var:preset|spacing|70"}}},"className":"is-style-main-layout"} -->
@@ -40,13 +40,14 @@
 
 		<!-- wp:column {"className":"is-style-main-layout-sidebar"} -->
 		<div class="wp-block-column is-style-main-layout-sidebar">
-			<!-- wp:template-part {"slug":"sidebar-post","theme":"x-t9","tagName":"aside"} /--></div>
+			<!-- wp:template-part {"slug":"sidebar-post","theme":"x-t9","tagName":"aside"} /-->
+		</div>
 		<!-- /wp:column -->
 	</div>
 	<!-- /wp:columns -->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-xl"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-xl"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
 	<!-- /wp:spacer -->
 </main>
 <!-- /wp:group -->

--- a/templates/page-2col.html
+++ b/templates/page-2col.html
@@ -4,8 +4,8 @@
 <main class="wp-block-group alignfull">
 	<!-- wp:template-part {"slug":"page-header-page","theme":"x-t9","tagName":"div","align":"full"} /-->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-lg"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 	<!-- /wp:spacer -->
 
 	<!-- wp:columns {"className":"is-style-main-layout"} -->
@@ -22,8 +22,8 @@
 	</div>
 	<!-- /wp:columns -->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-xl"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-xl"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
 	<!-- /wp:spacer -->
 </main>
 <!-- /wp:group -->

--- a/templates/page.html
+++ b/templates/page.html
@@ -4,14 +4,14 @@
 <main class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0">
 	<!-- wp:template-part {"slug":"page-header-page","theme":"x-t9","tagName":"div","align":"full"} /-->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-lg"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 	<!-- /wp:spacer -->
 
 	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-xl"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-xl"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
 	<!-- /wp:spacer -->
 </main>
 <!-- /wp:group -->

--- a/templates/search.html
+++ b/templates/search.html
@@ -28,14 +28,14 @@
 		class="wp-block-separator alignfull has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide" />
 	<!-- /wp:separator -->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-lg"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 	<!-- /wp:spacer -->
 
 	<!-- wp:template-part {"slug":"loop-archive","theme":"x-t9","tagName":"div"} /-->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-xl"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-xl"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
 	<!-- /wp:spacer -->
 </main>
 <!-- /wp:group -->

--- a/templates/single-1col.html
+++ b/templates/single-1col.html
@@ -4,15 +4,15 @@
 <main class="wp-block-group mt-0">
 	<!-- wp:template-part {"slug":"page-header-single","theme":"x-t9","tagName":"div","align":"full"} /-->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-lg"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 	<!-- /wp:spacer -->
 
 	<!-- wp:group -->
 	<div class="wp-block-group"><!-- wp:post-content {"layout":{"type":"constrained"}} /-->
 
-		<!-- wp:spacer {"height":"","className":"is-style-spacer-lg"} -->
-		<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+		<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+		<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 		<!-- /wp:spacer -->
 
 		<!-- wp:group {"layout":{"type":"flex","allowOrientation":false,"justifyContent":"space-between"}} -->
@@ -22,8 +22,8 @@
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:spacer {"height":"","className":"is-style-spacer-lg"} -->
-		<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+		<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+		<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 		<!-- /wp:spacer -->
 
 		<!-- wp:separator {"backgroundColor":"border-normal","className":"is-style-wide"} -->
@@ -39,7 +39,8 @@
 			<!-- wp:columns -->
 			<div class="wp-block-columns"><!-- wp:column {"width":"40px"} -->
 				<div class="wp-block-column" style="flex-basis:40px">
-					<!-- wp:avatar {"size":40,"style":{"border":{"radius":"20px"}}} /--></div>
+					<!-- wp:avatar {"size":40,"style":{"border":{"radius":"20px"}}} /-->
+				</div>
 				<!-- /wp:column -->
 
 				<!-- wp:column -->
@@ -107,8 +108,8 @@
 	</div>
 	<!-- /wp:columns -->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-xl"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-xl"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
 	<!-- /wp:spacer -->
 </main>
 <!-- /wp:group -->

--- a/templates/single.html
+++ b/templates/single.html
@@ -4,8 +4,8 @@
 <main class="wp-block-group">
 	<!-- wp:template-part {"slug":"page-header-single","theme":"x-t9","tagName":"div","align":"full"} /-->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-lg"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 	<!-- /wp:spacer -->
 
 	<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|70","left":"var:preset|spacing|70"}}},"className":"is-style-main-layout"} -->
@@ -14,8 +14,8 @@
 		<div class="wp-block-column">
 			<!-- wp:post-content /-->
 
-			<!-- wp:spacer {"height":"","className":"is-style-spacer-lg"} -->
-			<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+			<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+			<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 			<!-- /wp:spacer -->
 
 			<!-- wp:group {"layout":{"type":"flex","allowOrientation":false,"justifyContent":"space-between"}} -->
@@ -26,8 +26,8 @@
 			</div>
 			<!-- /wp:group -->
 
-			<!-- wp:spacer {"height":"","className":"is-style-spacer-lg"} -->
-			<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+			<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+			<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 			<!-- /wp:spacer -->
 
 			<!-- wp:separator {"backgroundColor":"border-normal","className":"is-style-wide"} -->
@@ -91,8 +91,8 @@
 	</div>
 	<!-- /wp:columns -->
 
-	<!-- wp:spacer {"height":"","className":"is-style-spacer-xl"} -->
-	<div style="height:" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
+	<!-- wp:spacer {"className":"is-style-spacer-xl"} -->
+	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
 	<!-- /wp:spacer -->
 </main>
 <!-- /wp:group -->

--- a/theme.json
+++ b/theme.json
@@ -180,7 +180,7 @@
 					"fluid": false,
 					"name": "X small",
 					"slug": "x-small",
-					"size": "clamp(11px, calc(11px + (100vw - 360px) * ( (12 -11) / (1200 - 360)) ), 12px)"
+					"size": "clamp(11px, calc(11px + (100vw - 360px) * ( (12 - 11) / (1200 - 360)) ), 12px)"
 				},
 				{
 					"fluid": false,


### PR DESCRIPTION
 [アクセシビリティ対応] 続きを読む #206
 [ 続きを読む]に `screen-reader-text` タグを追加しました

もしかして対応しなくてもよい？
`wp:post-excerpt `の` moreText `を消して` wp:read-more` ボタンを追加するのはヘンなかんじ
アクセシビリティ対応してる、他のブロックテーマを見てもやってないみたいです