### PR TITLE
【2人目確認待ち】Added support for the background image feature in Group blocks, introduced in WordPress 6.4.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Specification Change ] Added support for the background image feature in Group blocks, introduced in WordPress 6.4.
+
 1.17.1
 [ Bug fix ] Fix font size x-small
 

--- a/theme.json
+++ b/theme.json
@@ -12,6 +12,9 @@
 		"dimensions": {
 			"minHeight": true
 		},
+		"background": {
+			"backgroundImage": true
+		},
 		"color": {
 			"background": true,
 			"text": true,


### PR DESCRIPTION
https://make.wordpress.org/core/2023/10/17/miscellaneous-editor-changes-in-wordpress-6-4/

WordPress 6.4 環境でグループブロックに背景画像指定ができるように

## 確認方法

* WordPress 6.4 の環境でグループブロックを配置して背景画像設定UIが出ている事を確認
* もし気が向いたら https://make.wordpress.org/core/2023/10/17/miscellaneous-editor-changes-in-wordpress-6-4/ を読んで指定方法に問題がないか確認

![スクリーンショット 2023-11-02 3 32 57](https://github.com/vektor-inc/x-t9/assets/3272660/c0da08a2-f945-449f-9291-1dbbf53a646e)
