### PR TITLE
「続きを読む」リンクテキストの背景色を削除してみました

### DIFF
--- a/assets/_scss/_block.scss
+++ b/assets/_scss/_block.scss
@@ -2,10 +2,6 @@
  * Core block styles overrides
  */
 
-.wp-block-post-excerpt__more-text {
-	margin-block-start: var(--wp--custom--spacing--small);
-}
-
 /* Search ------------------------------------------------- */
 .wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper {
 	padding: 3px;

--- a/assets/_scss/_button.scss
+++ b/assets/_scss/_button.scss
@@ -5,7 +5,6 @@
 .btn,
 .wp-block-button__link,
 .wp-block-search__button,
-.wp-block-post-excerpt__more-link,
 .wp-block-button__link.has-primary-background-color {
 	transition: all 0.1s ease-in;
 	background-color: var(--wp--preset--color--primary);

--- a/assets/_scss/_query.scss
+++ b/assets/_scss/_query.scss
@@ -58,7 +58,6 @@
 	.wp-block-post-excerpt__more-text {
 		a {
 			font-size: var(--wp--preset--font-size--small);
-			padding: var(--wp--custom--spacing--button-sm);
 		}
 	}
 }


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
 【相談】クエリーループの中に抜粋を入れて、「続きを読む」リンクテキストにテキストを入れると背景色がついてしまう #220 

## どういう変更をしたか？
クエリーループの中に抜粋の「続きを読む」に背景色があってボタンみたいに表示されていたのを、ただの下線リンクにしました

* このプルリクで変更した事を記載してください
「続きを読む」スタイルの変更

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？

#### その他

- [ ] readme.txt に変更内容は書いたか？
- [ ] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [ ] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [ ] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

## レビュワーの確認方法・確認する内容など

## レビュワーに回す前の確認事項

- [ ] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
