### PR TITLE
【確認中】サイトタイトルタグへのデザイン指定をCSSファイルからtheme.jsonに移行

### DIFF
--- a/assets/_scss/_header.scss
+++ b/assets/_scss/_header.scss
@@ -1,11 +1,7 @@
 .wp-block-site-title {
 	a {
-		text-decoration: none;
-
 		&:hover {
-			text-decoration: underline;
 			text-decoration-thickness: 1px;
-			text-decoration-color: var(--wp--preset--color--text-normal);
 		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Specification Change ] Change the style specification of the 'site-title' block from a CSS file to theme.json.
 [ Specification Change ] Add style border radius 0 to .card 
 [ Translation ready ] button on featured-post-list
 

--- a/theme.json
+++ b/theme.json
@@ -314,6 +314,24 @@
 			}
 		},
 		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontWeight": "700",
+					"lineHeight": "var(--wp--custom--typography--line-height--heading)"
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				}
+			},
 			"core/button": {
 				"color": {
 					"background": "var(--wp--preset--color--primary)"


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

まぁ デザイン指定はできるだけ theme.json からにした方が良い...

## どういう変更をしたか？

サイトタイトルタグへのデザイン指定をCSSファイルからtheme.jsonに移行

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？
-> CSS変更なので無し

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

## レビュワーの確認方法・確認する内容など

* npm run build
* サイトタイトルの文字が太字になっている & hover で下線がつくかどうか

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
