### PR TITLE
【フロントエンドのみ】個別投稿で使っているカラムブロックのgap設定が効かない現象に対応

### DIFF
--- a/assets/_scss/_block_styles.scss
+++ b/assets/_scss/_block_styles.scss
@@ -31,7 +31,7 @@
 /*-------------------------------------------*/
 /*  Column
 /*-------------------------------------------*/
-body .is-style-main-layout.is-layout-flex {
+body :where(.is-style-main-layout.is-layout-flex) {
 	gap: var(--wp--custom--spacing--large);
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Bug Fix ] Fix column block gap setting not taking effect in individual posts
+
 1.20.0
 [ Specification Change ] TGM load from composer
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）


## どういう変更をしたか？

個別投稿で使っているカラムブロックのgap設定が効かない現象に対応しました。

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど
1. [サイトエディター] > [テンプレート] > [個別投稿] に移動
2. 使われているメインカラムとサイドバーのカラムで使用しているカラムブロックのgapに数値を入れて更新する
(今回はわかりやすく**0**にしています。)
![image](https://github.com/vektor-inc/x-t9/assets/21466284/eee79046-d413-495e-9e11-887af99690f9)
3. フロントエンドで見ると変更前はgapを0にしているはずが余白が開いている状態になります。
![image](https://github.com/vektor-inc/x-t9/assets/21466284/faf6f075-eb64-4c48-ac82-f30f0150dd74)
この状態から今回のプルリクで2で入力した数値に対応できるようにしました。
![image](https://github.com/vektor-inc/x-t9/assets/21466284/b2fe41db-6874-4358-914c-ebe5488d4a56)

## レビュワーの確認方法・確認する内容など
1. [サイトエディター] > [テンプレート] > [個別投稿] に移動します。
2. 使われているメインカラムとサイドバーのカラムで使用しているカラムブロックのgapに数値を入れて更新します。
3. フロントエンドで2で入力した数値がカラムブロックに反映されているか確認してください。

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
