### PR TITLE
【確認中】fix:VK グリッドカラムカードは display: grid;で .is-layout-constrained の要素がmargin:auto;だと中央に寄ってしまうので打ち消し

### DIFF
--- a/assets/_scss/_block_width_editor.scss
+++ b/assets/_scss/_block_width_editor.scss
@@ -15,6 +15,11 @@ body {
 		margin-left: auto;
 		margin-right: auto;
 	}
+	// VK グリッドカラムカードは display: grid;で .is-layout-constrained の要素がmargin:auto;だと中央に寄ってしまうので打ち消し
+	.vk_gridcolcard_item_body .is-layout-constrained{
+		margin-left: unset;
+		margin-right: unset;
+	}
 	:is( 
 		.edit-post-visual-editor__post-title-wrapper,
 		.block-editor-block-list__layout.is-root-container

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Editor Design Bug fix ]Editor: Fixed incorrect placement when vk_gridcolcard_item_body has .is-layout-constrained.
 [ Specification Change ] Allow using CSS level 4 viewport-relative units
 [ Editor Design Bug Fix ]Fix the width being wrong when setting to alignwide in editor
 [ Design Bug fix ]Fix indented li > ul margin in list__block


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/x-t9/issues/248

## どういう変更をしたか？

* このプルリクで変更した事を記載してください

編集画面用のCSSで`.is-layout-constrained`に`margin-left`、`right`に`auto`がつきますが、`.vk_gridcolcard_item_body` では `display: grid;`になっているため、中に`.is-layout-constrained`があると、`margin-left`と`right`の`auto`が効いて、配置が中央によってしまうため、`.vk_gridcolcard_item_body` の中の`.is-layout-constrained`の`margin`は`unset`で打ち消しました。

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. VK グリッドカラムカードを配置します。
2. VK グリッドカラムアイテム内に段落テキストで適当に文字を打ちます。グループブロックでラップします。グループブロックでラップしても中央によらないことを確認しました。

## レビュワーの確認方法・確認する内容など

1. VK グリッドカラムカードを配置します。
2. VK グリッドカラムアイテム内に段落テキストで適当に文字を打ちます。グループブロックでラップします。グループブロックでラップしても中央によらないことを確認してください。


## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
