### PR TITLE
【確認待ち】クラス名 has-vk-color-primary-border-color のカラーを追加

### DIFF
--- a/assets/_scss/_variables.scss
+++ b/assets/_scss/_variables.scss
@@ -16,7 +16,8 @@ body {
 	// cope with VK Blocks
 	--wp--preset--color--vk-color-primary: var(--wp--preset--color--primary);
 }
-.has-vk-color-primary-border-color { // For lightning theme
+// Support lightning theme class
+.has-vk-color-primary-border-color { 
     border-color: var(--wp--preset--color--vk-color-primary);
 }
 /*-----------------------------------------------------------------------------------

--- a/assets/_scss/_variables.scss
+++ b/assets/_scss/_variables.scss
@@ -16,7 +16,9 @@ body {
 	// cope with VK Blocks
 	--wp--preset--color--vk-color-primary: var(--wp--preset--color--primary);
 }
-
+.has-vk-color-primary-border-color { // For lightning theme
+    border-color: var(--wp--preset--color--vk-color-primary);
+}
 /*-----------------------------------------------------------------------------------
  * 親のラッパーで背景が濃い場合用のテキスト色が指定されている場合に、通常の色をDarkBG用の色で上書きする
  */


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/x-t9/issues/260

## どういう変更をしたか？

* このプルリクで変更した事を記載してください

VK パターンライブラリでLightningテーマのパターンからX-T9にコピペした時に、.has-vk-color-primary-border-colorのクラス名のカラーがX-T9には指定されていないので、VK パターンライブラリを利用する人用に追加しました。

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？

#### その他

- [ ] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

**※ VK パターンライブラリを利用している人にしか関係ないようなクラス名ですので、readmeに書いていませんが、必要でしたら書きます。**

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

[このパターン](https://patterns.vektor-inc.co.jp/vk-patterns/cram-school_voice-2/)をX-T9テーマに貼り付けて、「保護者の声」部分の横並びブロックのボーダーの色が、X-T9のプライマリーカラーになっていることを確認しました。

## レビュワーの確認方法・確認する内容など

[このパターン](https://patterns.vektor-inc.co.jp/vk-patterns/cram-school_voice-2/)をX-T9テーマに貼り付けて、「保護者の声」部分の横並びブロックのボーダーの色が、X-T9のプライマリーカラーになっていることを確認してください。

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
