### PR TITLE
【確認待ち】［css微修正］submenuの背景に色を指定すると has-background で余白がついてしまうので打ち消し

### DIFF
--- a/assets/_scss/_navigation.scss
+++ b/assets/_scss/_navigation.scss
@@ -102,6 +102,9 @@
 				color: #fff; // No relation under Bright BG and Dark BG
 			}
 		}
+		&:where(.has-background){
+			padding:unset; // Cancel the padding added by the WordPress core
+		}
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Bug fix ] Fixed padding being added when the submenu has background.
+
 1.21.1
 [ Design Bug fix ][ 6.5 ] Fixed an issue that prevented editing of the fixed header area in WordPress 6.5.
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/x-t9/issues/265

## どういう変更をしたか？

* このプルリクで変更した事を記載してください

`.wp-block-navigation__submenu-container`に`.has-background`のクラス名がある場合にpaddingをunsetしました。

cssの微修正なので1人確認でよさそうです。

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

cssの微修正のみです

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？

cssの微修正のみですのでテストは書いていません

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

ナビゲーションブロックでサブメニューをもつメニューを設置して、ブロックの設定の［サブメニューとオーバーレイ背景］から背景色を設定します。
フロント画面でサブメニューにpaddingがついていないことを確認しました。

**▼修正前：paddingが付いている状態**
![スクリーンショット 2024-04-25 11 36 15](https://github.com/vektor-inc/x-t9/assets/5525368/3971631e-61ba-4c5f-b159-9a48ea941615)
**▼修正後：paddingが付いていない状態**
![スクリーンショット 2024-04-25 11 36 43](https://github.com/vektor-inc/x-t9/assets/5525368/fb8f4030-da7e-4ae9-ad07-538f852ae1c9)

## レビュワーの確認方法・確認する内容など

ナビゲーションブロックでサブメニューをもつメニューを設置して、ブロックの設定の［サブメニューとオーバーレイ背景］から背景色を設定します。
フロント画面でサブメニューにpaddingがついていないことを確認してください。

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
