### PR TITLE
pタグから下部余白削除 / Remove the bottom margin from the p tag.

### DIFF
--- a/assets/_scss/_common_margin-vertical.scss
+++ b/assets/_scss/_common_margin-vertical.scss
@@ -10,13 +10,13 @@ p{
 		// 意図する余白 - この要素の上側のレディング - 上の要素の下側のレディング（要素検出が難しいので同じと仮定）
 		// 意図する余白 - ( line-height - 文字サイズ ) / 2(上下片方だけにする) ) -（上の要素の下側のレディング（同じとして）
 		margin-block-start:calc( var(--wp--custom--spacing--small) - ( ( 1.5rem - 1rem ) / 2 ) -  ( ( 1.5rem - 1rem ) / 2 ) );
-		margin-block-end:calc( var(--wp--custom--spacing--small) - ( ( 1.5rem - 1rem ) / 2 ) -  ( ( 1.5rem - 1rem ) / 2 ) );
 		&:first-child {
 			margin-block-start: 0;
 		}
-		&:last-child {
-			margin-block-end: 0;
-		}
+		// もともとグループ内の最後の要素だけ余白ナシにしていたが、
+		// スペーサーの余白に加算されてしまい、意図しない余白が生じるため、全ての p 要素に余白を持たせるように変更
+		margin-bottom:0;
+		margin-block-end: 0;
 	}
 }
 :is( h2, h3, h4, h5, h6 ) {

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Specification Change ] Remove the bottom margin from the p tag.
+
 1.22.1
 [ Design Bug fix ] Fix Description -- SNS / Logo -- Nav - Contact pattern alignment
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

pタグの下に余白があると、その下にスペーサーを配置した時に、スペーサーに加算した余白がつくため、余白の大きさがサイト全体で安定しないため、毎回手動でスペース前のpタグに margin-bottom:0; 指定をする必要がある。

その事を知らない一般ユーザーがそのまま使うと、余白が安定してない「なんかどこか素人っぽい」サイトになってしまう。

※ もともとこの余白はつかないように作ってあったつもりだったが、おそらく margin-bottom 指定だった（margin-topと総裁される）のが margin-block-end になって加算されるようになったとか...？

## どういう変更をしたか？

pタグ下部の余白を削除

■ Before

![スクリーンショット 2024-04-28 8 58 18](https://github.com/vektor-inc/x-t9/assets/3272660/06b1835c-c48c-4afe-9de8-522c7645084b)

■ After

![スクリーンショット 2024-04-28 8 54 50](https://github.com/vektor-inc/x-t9/assets/3272660/e2796fae-6762-40b2-9512-a8e52d32defe)

### 影響について

* pタグ上部にはついているので、従来の文章の見た目が崩れる事は少ない
* もともとグループブロック内などの最後の要素の場合は下部の余白は0に指定してあった

以上の事から多少の影響は出るかもしれないが、今後を踏まえると今のうちに削除した方が良いと判断

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

## レビュワーの確認方法・確認する内容など

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
