### PR TITLE
p タグの次の要素がスペーサーだった場合だけ下部余白がなくなるように変更

### DIFF
--- a/assets/_scss/_common_margin-vertical.scss
+++ b/assets/_scss/_common_margin-vertical.scss
@@ -52,6 +52,12 @@ body .wp-site-blocks > :is(
 		margin-top: 0;
 }
 
+// 次の要素が スペーサーブロック / レスポンシブスペーサー の場合は margin-bottom を 0 にする
+*:has( + :is( .wp-block-spacer, .vk_spacer ) ){
+	margin-bottom:0;
+	margin-block-end: 0;
+}
+
 body :is( .wp-site-blocks, .is-layout-constrained, .is-layout-flow ) {
 	// スペーサーブロック / グループ / カバーの 次の要素の上部には margin-top が自動的に 0 になるようにする
 	// Delete margin-top from next element of spacer / group / cover block

--- a/assets/_scss/_common_margin-vertical.scss
+++ b/assets/_scss/_common_margin-vertical.scss
@@ -10,13 +10,13 @@ p{
 		// 意図する余白 - この要素の上側のレディング - 上の要素の下側のレディング（要素検出が難しいので同じと仮定）
 		// 意図する余白 - ( line-height - 文字サイズ ) / 2(上下片方だけにする) ) -（上の要素の下側のレディング（同じとして）
 		margin-block-start:calc( var(--wp--custom--spacing--small) - ( ( 1.5rem - 1rem ) / 2 ) -  ( ( 1.5rem - 1rem ) / 2 ) );
+		margin-block-end:calc( var(--wp--custom--spacing--small) - ( ( 1.5rem - 1rem ) / 2 ) - ( ( 1.5rem - 1rem ) / 2 ) );
 		&:first-child {
 			margin-block-start: 0;
 		}
-		// もともとグループ内の最後の要素だけ余白ナシにしていたが、
-		// スペーサーの余白に加算されてしまい、意図しない余白が生じるため、全ての p 要素に余白を持たせるように変更
-		margin-bottom:0;
-		margin-block-end: 0;
+		&:last-child {
+			margin-block-end: 0;
+		}
 	}
 }
 :is( h2, h3, h4, h5, h6 ) {

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Bug fix ] Rollback deleted p tag margin-bottom 1.23.0 / Delete margin-bottom in case of only next block is spacer.
 [ Specifiction Change ] 
  --wp--custom--content-size--normal -> --wp--custom--width--content
  --wp--custom--layout--sidebar -> --wp--custom--width--sidebar


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/x-t9/pull/270 で p タグ下部から余白を削除したがさすがに影響が大きかった

## どういう変更をしたか？

p タグの次の要素がスペーサーだった場合に余白がなくなるように変更

■ Before

![スクリーンショット 2024-05-09 17 15 26](https://github.com/vektor-inc/x-t9/assets/3272660/9e8e92fa-1853-437f-97f7-4f90b85a6830)

■ After

![スクリーンショット 2024-05-09 17 16 01](https://github.com/vektor-inc/x-t9/assets/3272660/43afc686-0855-47e7-8646-1155df15c26c)

#### その他

- [ ] readme.txt に変更内容は書いたか？
- [ ] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [ ] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [ ] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

## レビュワーの確認方法・確認する内容など

## レビュワーに回す前の確認事項

- [ ] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
