### PR TITLE
[ Other ][ 6.6 ] Fix readmore and pagenation button text color

### DIFF
--- a/assets/_scss/_button.scss
+++ b/assets/_scss/_button.scss
@@ -9,11 +9,14 @@
 .wp-block-button__link.has-primary-background-color {
 	transition: all 0.1s ease-in;
 	background-color: var(--wp--preset--color--primary);
-	color: #fff; // BG Secondary and Dark both white
 	text-decoration: none;
 	border-radius: var(--wp--custom--radius--button);
 	&:hover {
 		--wp--preset--color--primary: var(--wp--preset--color--primary-hover);
+	}
+	:root & {
+		text-decoration: none;
+		color: #fff; // BG Secondary and Dark both white
 	}
 }
 /* ---------------------------------

--- a/assets/_scss/_pagenation.scss
+++ b/assets/_scss/_pagenation.scss
@@ -9,12 +9,13 @@
 	&-next {
 		line-height: 1;
 		padding: 10px 1em;
-		color: #fff;
 		background-color: var(--wp--preset--color--primary);
-		text-decoration: none;
-
 		&:hover {
 			background-color: var(--wp--preset--color--primary-hover);
+		}
+		:root & {
+			text-decoration: none;
+			color: #fff; // BG Secondary and Dark both white
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
-[ Other ][ 6.6 ] Attend to WordPress 6.6 ( Fix scrolled header  )
+[ Other ][ 6.6 ] Fix readmore and pagenation button text color
+[ Other ][ 6.6 ] Fix scrolled header
 [ Design Tuning ] Add styles to inline kbd block.
 [ Bug fix ] Fix the display when vertically aligned in the center and right aligned.
 


### PR DESCRIPTION
WordPress 6.6

■ Before
![スクリーンショット 2024-07-05 0 45 43](https://github.com/vektor-inc/x-t9/assets/3272660/7f0e3279-fd43-43f9-bcc6-f75477853add)

■ After
![スクリーンショット 2024-07-05 0 43 43](https://github.com/vektor-inc/x-t9/assets/3272660/a22141ed-2bab-456f-9245-be564a8eaf6e)
