### PR TITLE
【2人目確認中】［6.6-RC2］［css微修正］編集画面にてコアのボタンブロックのスタイル輪郭で背景色が入ってしまうのを修正

### DIFF
--- a/assets/_scss/_button.scss
+++ b/assets/_scss/_button.scss
@@ -31,13 +31,15 @@
 .wp-block-button.is-style-outline {
 	& > .wp-block-button__link {
 		border-width:1px;
+		// 6.6で コアのデフォルトスタイルが負けるようになり、背景色がついてしまうので追加
+		background-color:transparent;
+		color: currentColor;
 	}
 	& > .wp-block-button__link:not(.has-background):hover {
 		background-color: var(--wp--preset--color--primary-hover);
 		color: #fff;
 	}
 	& > .has-text-color:hover {
-		// background-color: currentColor;
 		color:#fff !important;
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Bug Fix ] Editor:Fix outline background of button style in WP6.6.
+
 1.25.0
 [ Other ][ 6.6 ] Fix readmore and pagenation button text color
 [ Other ][ 6.6 ] Fix scrolled header


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/x-t9/issues/281

## どういう変更をしたか？

* このプルリクで変更した事を記載してください

6.6で 編集画面にてボタンのスタイルの輪郭(is-style-outline)の時に背景色がついてしまうので、cssを修正しました。

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？
cssの修正のみ

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど
固定ページなどにコアのボタンブロックを配置して、ボタンのスタイルを「輪郭」(outline)にし、背景色が透明になっていることを編集画面で確認しました。念の為フロント画面も背景が透明になっていることを確認しました。


## レビュワーの確認方法・確認する内容など

固定ページなどにコアのボタンブロックを配置して、ボタンのスタイルを「輪郭」(outline)にし、背景色が透明になっていることを編集画面で確認しました。念の為フロント画面も背景が透明になっていることを確認しました。

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
