### PR TITLE
Accommodate width adjustment on WordPress 6.6 edit screen

### DIFF
--- a/assets/_scss/_block_width_editor-wp65.scss
+++ b/assets/_scss/_block_width_editor-wp65.scss
@@ -1,0 +1,118 @@
+// In editor screen need to no content outer layout
+// ★ 編集画面ではアウターでのコンテンツ幅 + マイナスオフセットではなく、max-width で処理する
+// * constrained の中にある .alignfull や .alignwide がある場合は constrained の幅を全幅にする
+
+//////////////////////////////////////////////////////////////
+/// Variable Setting
+//////////////////////////////////////////////////////////////
+
+.editor-styles-wrapper{
+	--vk-editor-container:calc(var(--wp--custom--width--wrapper) * 0.8);
+	--vk-editor-sidebar:280px;
+	--vk-editor-leftmenu:160px;
+	--vk-editor-leftmenu-folded:36px;
+	--vk-editor-list-view-sidebar:350px;
+	--wp--custom--width--content : var(--vk-editor-container);
+	--wp--style--global--wide-size: calc( var(--vk-editor-container) + ( var(--wp--custom--width--wrapper) - var(--vk-editor-container) ) / 2 );
+}
+
+.editor-styles-wrapper {
+	box-sizing: border-box !important;
+}
+
+// 左管理メニュー非表示 //////////////////////////////////
+body.is-fullscreen-mode {
+	// 右表示
+	.edit-post-layout.is-sidebar-opened {
+		.editor-styles-wrapper {
+			--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-sidebar));
+		}
+		// リストビュー表示
+		.interface-interface-skeleton__body:has(.interface-interface-skeleton__secondary-sidebar){
+			.editor-styles-wrapper {
+				--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-sidebar) - var(--vk-editor-list-view-sidebar) );
+			}
+		}
+	}
+	// リストビュー表示
+	.interface-interface-skeleton__body:has(.interface-interface-skeleton__secondary-sidebar){
+		.editor-styles-wrapper {
+			--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-list-view-sidebar) );
+		}
+	}
+}
+
+// 左管理メニュー表示 //////////////////////////////////
+body:not(.is-fullscreen-mode) {
+	.editor-styles-wrapper {
+		--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-leftmenu));
+	}
+	// リストビュー表示
+	.interface-interface-skeleton__body:has(.interface-interface-skeleton__secondary-sidebar){
+		.editor-styles-wrapper {
+			--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-leftmenu) - var(--vk-editor-list-view-sidebar) );
+		}
+	}
+	// 右表示
+	.is-sidebar-opened {
+		.editor-styles-wrapper {
+			--wp--custom--width--wrapper:calc( 100dvw - var(--vk-editor-leftmenu) - var(--vk-editor-sidebar) );
+		}
+		// リストビュー表示
+		.interface-interface-skeleton__body:has(.interface-interface-skeleton__secondary-sidebar){
+			.editor-styles-wrapper {
+				--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-leftmenu) - var(--vk-editor-sidebar) - var(--vk-editor-list-view-sidebar) );
+			}
+		}
+	}
+}
+// 左管理メニュー表示（ 折りたたみ ） //////////////////////////////////
+body:not(.is-fullscreen-mode).auto-fold,
+body:not(.is-fullscreen-mode).folded {
+	.editor-styles-wrapper {
+		--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-leftmenu-folded));
+	}
+	// リストビュー表示
+	.interface-interface-skeleton__body:has(.interface-interface-skeleton__secondary-sidebar){
+		.editor-styles-wrapper {
+			--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-leftmenu-folded) - var(--vk-editor-list-view-sidebar) );
+		}
+	}
+	// 右表示
+	.is-sidebar-opened {
+		.editor-styles-wrapper {
+			--wp--custom--width--wrapper:calc( 100dvw - var(--vk-editor-leftmenu-folded) - var(--vk-editor-sidebar) );
+		}
+		// リストビュー表示
+		.interface-interface-skeleton__body:has(.interface-interface-skeleton__secondary-sidebar){
+			.editor-styles-wrapper {
+				--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-leftmenu-folded) - var(--vk-editor-sidebar) - var(--vk-editor-list-view-sidebar) );
+			}
+		}
+	}
+}
+
+//////////////////////////////////////////////////////////////
+/// .is-layout-constrained の幅の制御
+//////////////////////////////////////////////////////////////
+
+.editor-styles-wrapper {
+	// .is-layout-constrained の最大幅をコンテンツ幅に指定
+	// サイトエディタのの直下でコンテンツ幅を指定したアウターを使ってしまっている
+	// → しかし編集画面ではマイナスオフセットを使わず、max-width で処理しているので、コンテンツ幅になっていると都合が悪い
+	// → そのため、.is-root-container と .is-root-container > .wp-block はコンテンツ幅を除外している
+	.is-layout-constrained:where(:not(.alignfull)):where(:not(.alignwide)):where(:not(.is-root-container)):where(:not(.is-root-container > .wp-block)) {
+		max-width:var(--vk-editor-container);
+		margin-left:auto;
+		margin-right:auto;
+	}
+	// constrained の中にある .alignfull や .alignwide がある場合は constrained の幅を全幅にする
+	.is-layout-constrained:where(:has(:is(.alignfull,.alignwide))),
+	.block-editor-block-list__layout.is-root-container > :where(:not(.alignleft):not(.alignright):not(.alignfull)):has(:is(.alignfull,.alignwide)){
+		max-width: var(--wp--custom--width--wrapper);
+		.alignwide {
+			margin-left:auto !important;
+			margin-right:auto !important;
+		}
+	}
+}

--- a/assets/_scss/_block_width_editor.scss
+++ b/assets/_scss/_block_width_editor.scss
@@ -2,117 +2,73 @@
 // ★ 編集画面ではアウターでのコンテンツ幅 + マイナスオフセットではなく、max-width で処理する
 // * constrained の中にある .alignfull や .alignwide がある場合は constrained の幅を全幅にする
 
-//////////////////////////////////////////////////////////////
-/// Variable Setting
-//////////////////////////////////////////////////////////////
-
-.editor-styles-wrapper{
-	--vk-editor-container:calc(var(--wp--custom--width--wrapper) * 0.8);
-	--vk-editor-sidebar:280px;
-	--vk-editor-leftmenu:160px;
-	--vk-editor-leftmenu-folded:36px;
-	--vk-editor-list-view-sidebar:350px;
-	--wp--custom--width--content : var(--vk-editor-container);
-	--wp--style--global--wide-size: calc( var(--vk-editor-container) + ( var(--wp--custom--width--wrapper) - var(--vk-editor-container) ) / 2 );
-}
-
 .editor-styles-wrapper {
-	box-sizing: border-box !important;
-}
+	--vk-width-editor-sidebar:0px; 
+	--vk-width-editor-leftmenu:0px;
+	--vk-width-editor-list-view-sidebar:0px; // Be aware that calc cannot calculate if there is no unit.
 
-// 左管理メニュー非表示 //////////////////////////////////
-body.is-fullscreen-mode {
-	// 右表示
-	.edit-post-layout.is-sidebar-opened {
-		.editor-styles-wrapper {
-			--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-sidebar));
-		}
-		// リストビュー表示
-		.interface-interface-skeleton__body:has(.interface-interface-skeleton__secondary-sidebar){
-			.editor-styles-wrapper {
-				--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-sidebar) - var(--vk-editor-list-view-sidebar) );
-			}
-		}
-	}
-	// リストビュー表示
-	.interface-interface-skeleton__body:has(.interface-interface-skeleton__secondary-sidebar){
-		.editor-styles-wrapper {
-			--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-list-view-sidebar) );
-		}
+	// full
+	--wp--custom--width--wrapper:calc( 100svw - var(--vk-width-editor-sidebar) - var(--vk-width-editor-leftmenu) - var(--vk-width-editor-list-view-sidebar) );
+
+	// wide
+	--wp--custom--width--wide:calc(var(--wp--custom--width--wrapper) * 0.9 );
+	--wp--style--global--wide-size:calc(var(--wp--custom--width--wrapper) * 0.9 );
+
+	// content
+	.block-editor-block-list__layout.is-root-container > :where(:not(.alignleft):not(.alignright):not(.alignfull)),
+	.is-layout-constrained > * {
+		--wp--custom--width--content:calc(var(--wp--custom--width--wrapper) * 0.8 );
+		--wp--style--global--content-size:calc(var(--wp--custom--width--wrapper) * 0.8 );
 	}
 }
 
-// 左管理メニュー表示 //////////////////////////////////
-body:not(.is-fullscreen-mode) {
-	.editor-styles-wrapper {
-		--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-leftmenu));
-	}
-	// リストビュー表示
-	.interface-interface-skeleton__body:has(.interface-interface-skeleton__secondary-sidebar){
-		.editor-styles-wrapper {
-			--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-leftmenu) - var(--vk-editor-list-view-sidebar) );
-		}
-	}
-	// 右表示
-	.is-sidebar-opened {
-		.editor-styles-wrapper {
-			--wp--custom--width--wrapper:calc( 100dvw - var(--vk-editor-leftmenu) - var(--vk-editor-sidebar) );
-		}
-		// リストビュー表示
-		.interface-interface-skeleton__body:has(.interface-interface-skeleton__secondary-sidebar){
-			.editor-styles-wrapper {
-				--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-leftmenu) - var(--vk-editor-sidebar) - var(--vk-editor-list-view-sidebar) );
-			}
-		}
-	}
+//  In case the left sidebar is open ( not full screen mode )
+html:has(:not(.is-fullscreen-mode)) .editor-styles-wrapper {
+	--vk-width-editor-leftmenu:160px;
 }
-// 左管理メニュー表示（ 折りたたみ ） //////////////////////////////////
-body:not(.is-fullscreen-mode).auto-fold,
-body:not(.is-fullscreen-mode).folded {
-	.editor-styles-wrapper {
-		--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-leftmenu-folded));
-	}
-	// リストビュー表示
-	.interface-interface-skeleton__body:has(.interface-interface-skeleton__secondary-sidebar){
-		.editor-styles-wrapper {
-			--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-leftmenu-folded) - var(--vk-editor-list-view-sidebar) );
-		}
-	}
-	// 右表示
-	.is-sidebar-opened {
-		.editor-styles-wrapper {
-			--wp--custom--width--wrapper:calc( 100dvw - var(--vk-editor-leftmenu-folded) - var(--vk-editor-sidebar) );
-		}
-		// リストビュー表示
-		.interface-interface-skeleton__body:has(.interface-interface-skeleton__secondary-sidebar){
-			.editor-styles-wrapper {
-				--wp--custom--width--wrapper:calc(100dvw - var(--vk-editor-leftmenu-folded) - var(--vk-editor-sidebar) - var(--vk-editor-list-view-sidebar) );
-			}
-		}
-	}
+html:has(:not(.is-fullscreen-mode)):has(.folded) .editor-styles-wrapper {
+	--vk-width-editor-leftmenu:36px;
+}
+
+// In case the right sidebar is open
+html:has(.editor-sidebar) .editor-styles-wrapper {
+	--vk-width-editor-sidebar:280px; 
+}
+
+// In case the block list view is open
+body:has(.interface-interface-skeleton__secondary-sidebar) .editor-styles-wrapper{
+	--vk-width-editor-list-view-sidebar:350px;
+}
+
+/// mobile / tablet iframe adjustment //////////////////////////
+body.block-editor-iframe__body.editor-styles-wrapper{
+	// タブレット / モバイル の場合はサイドパネルの幅の変数の値を0にする
+	--vk-width-editor-sidebar:0px;
+	--vk-width-editor-leftmenu:0px;
+	--vk-width-editor-list-view-sidebar:0px;
 }
 
 //////////////////////////////////////////////////////////////
-/// .is-layout-constrained の幅の制御
+/// full & wide
 //////////////////////////////////////////////////////////////
 
-.editor-styles-wrapper {
-	// .is-layout-constrained の最大幅をコンテンツ幅に指定
-	// サイトエディタのの直下でコンテンツ幅を指定したアウターを使ってしまっている
-	// → しかし編集画面ではマイナスオフセットを使わず、max-width で処理しているので、コンテンツ幅になっていると都合が悪い
-	// → そのため、.is-root-container と .is-root-container > .wp-block はコンテンツ幅を除外している
-	.is-layout-constrained:where(:not(.alignfull)):where(:not(.alignwide)):where(:not(.is-root-container)):where(:not(.is-root-container > .wp-block)) {
-		max-width:var(--vk-editor-container);
-		margin-left:auto;
-		margin-right:auto;
+// [data-align=full] {
+// 	&,
+// 	& > div:where(:not(.is-layout-constrained)) { // 編集画面で data-align の内側に div が追加されてしまうため、内側の div にも全幅指定しないと全幅が効かない
+// 		width:var(--vk-width-full);
+// 	}
+// }
+
+[data-align=wide] {
+	margin-left:auto;
+	margin-right:auto;
+	width:var(--wp--custom--width--wide);
+	html &,
+	& > div {
+		width:var(--wp--custom--width--wide);
+		max-width:var(--wp--custom--width--wide);
 	}
-	// constrained の中にある .alignfull や .alignwide がある場合は constrained の幅を全幅にする
-	.is-layout-constrained:where(:has(:is(.alignfull,.alignwide))),
-	.block-editor-block-list__layout.is-root-container > :where(:not(.alignleft):not(.alignright):not(.alignfull)):has(:is(.alignfull,.alignwide)){
-		max-width: var(--wp--custom--width--wrapper);
-		.alignwide {
-			margin-left:auto !important;
-			margin-right:auto !important;
-		}
+	div:where(:not(.is-layout-constrained)) {
+		max-width:var(--wp--custom--width--wide);
 	}
 }

--- a/assets/_scss/_block_width_editor.scss
+++ b/assets/_scss/_block_width_editor.scss
@@ -1,6 +1,5 @@
 // In editor screen need to no content outer layout
-// ★ 編集画面ではアウターでのコンテンツ幅 + マイナスオフセットではなく、max-width で処理する
-// * constrained の中にある .alignfull や .alignwide がある場合は constrained の幅を全幅にする
+// * .is-root-container に限って .is-layout-constrained でもコンテンツ幅にならないように指定してあり、中の要素は max-width でコンテンツ幅を処理している
 
 .editor-styles-wrapper {
 	--vk-width-editor-sidebar:0px; 
@@ -52,12 +51,12 @@ body.block-editor-iframe__body.editor-styles-wrapper{
 /// full & wide
 //////////////////////////////////////////////////////////////
 
-// [data-align=full] {
-// 	&,
-// 	& > div:where(:not(.is-layout-constrained)) { // 編集画面で data-align の内側に div が追加されてしまうため、内側の div にも全幅指定しないと全幅が効かない
-// 		width:var(--vk-width-full);
-// 	}
-// }
+// ルートコンテナ以外の .is-layout-constrained には max-width を指定
+.is-layout-constrained:where(:not(.is-root-container)) {
+	max-width: var(--wp--custom--width--content);
+	margin-left:auto;
+	margin-right:auto;
+}
 
 [data-align=wide] {
 	margin-left:auto;

--- a/assets/_scss/editor-wp65.scss
+++ b/assets/_scss/editor-wp65.scss
@@ -4,7 +4,7 @@
  * Edit screen override
  */
 
-@import 'block_width_editor';
+@import 'block_width_editor-wp65';
 @import 'plugin-override/vk-blocks-override-width_editor';
 
 .edit-post-visual-editor__post-title-wrapper {

--- a/assets/_scss/plugin-override/_vk-blocks-override-width.scss
+++ b/assets/_scss/plugin-override/_vk-blocks-override-width.scss
@@ -17,7 +17,7 @@
 // .vk_outer-paddingLR-none => content size
 .vk_outer-width-full.vk_outer-paddingLR-none {
 	.vk_outer_container {
-		max-width: var(--wp--style--global--content-size);
+		max-width: var(--wp--custom--width--content);
 		margin-left: auto;
 		margin-right: auto;
 	}

--- a/functions.php
+++ b/functions.php
@@ -20,7 +20,14 @@ if ( ! function_exists( 'xt9_support' ) ) :
 
 		// Enqueue editor styles.
 		add_editor_style( 'assets/css/style.css' );
-		add_editor_style( 'assets/css/editor.css' );
+
+		if ( version_compare( $GLOBALS['wp_version'], '6.5', '<' ) ) {
+			// WordPress under 6.5
+			add_editor_style( 'assets/css/editor-65.css' );
+		} else {
+			// WordPress over 6.6
+			add_editor_style( 'assets/css/editor.css' );
+		}
 	}
 	add_action( 'after_setup_theme', 'xt9_support' );
 endif;

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Other ][ 6.6 ] Accommodate width adjustment on WordPress 6.6 edit screen
 [ Design Bug Fix ] Editor:Fix outline background of button style in WP6.6.
 
 1.25.0

--- a/theme.json
+++ b/theme.json
@@ -4,7 +4,7 @@
 	"settings": {
 		"layout": {
 			"contentSize": "var(--wp--custom--width--content)",
-			"wideSize": "calc( var(--wp--custom--width--content) + ( var(--wp--custom--width--wrapper) - var(--wp--custom--width--content) ) / 2 )"
+			"wideSize": "var(--wp--custom--width--wide)"
 		},
 		"position": {
 			"sticky": true
@@ -254,6 +254,7 @@
 			"width": {
 				"wrapper": "100dvw",
 				"content": "min( 1110px, 90vw )",
+				"wide": "calc( var(--wp--custom--width--content) + ( var(--wp--custom--width--wrapper) - var(--wp--custom--width--content) ) / 2 )",
 				"sidebar": "220px"
 			},
 			"layout": {


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）


## どういう変更をしたか？

* 6.5 と 6.6 で編集画面用のCSSを分離
* 6.6 対応幅処理 

■ Before
![スクリーンショット 2024-07-17 11 33 34](https://github.com/user-attachments/assets/e01154a3-e908-437f-a473-beebc94aba68)

■ After
![スクリーンショット 2024-07-17 11 34 20](https://github.com/user-attachments/assets/8130448f-bcbd-4634-a67a-7a63e367139e)


