### PR TITLE
Fixed the width of the post title on the edit screen

### DIFF
--- a/assets/_scss/_block_width_editor.scss
+++ b/assets/_scss/_block_width_editor.scss
@@ -14,6 +14,7 @@
 	--wp--style--global--wide-size:calc(var(--wp--custom--width--wrapper) * 0.9 );
 
 	// content
+	--wp--custom--width--content:calc(var(--wp--custom--width--wrapper) * 0.8 );
 	.block-editor-block-list__layout.is-root-container > :where(:not(.alignleft):not(.alignright):not(.alignfull)),
 	.is-layout-constrained > * {
 		--wp--custom--width--content:calc(var(--wp--custom--width--wrapper) * 0.8 );

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Bug Fix ] Fixed the width of the post title on the edit screen
+
 1.26.0
 [ Other ][ 6.6 ] Accommodate width adjustment on WordPress 6.6 edit screen
 [ Design Bug Fix ] Editor:Fix outline background of button style in WP6.6.


### PR DESCRIPTION
■ Before

![スクリーンショット 2024-07-19 12 02 46](https://github.com/user-attachments/assets/76f7dda5-8418-4085-800e-87f21491d413)


■ After

![スクリーンショット 2024-07-19 11 51 59](https://github.com/user-attachments/assets/328c66ed-f0bf-422e-a0d7-76b5ac542f70)
