### PR TITLE
[ Design Bug Fix ] First aid for an issue where the value of --wp--preset--font-size--huge defined in theme.json is being overwritten by WordPress

### DIFF
--- a/assets/_scss/_variables_wp660.scss
+++ b/assets/_scss/_variables_wp660.scss
@@ -1,0 +1,3 @@
+:root body {
+	--wp--preset--font-size--huge:clamp(24.12px, calc( 24.12px + (100vw - 360px) * ( (32.18 - 24.12) / (1200 - 360)) ), 32.18px);
+}

--- a/assets/_scss/style.scss
+++ b/assets/_scss/style.scss
@@ -1,6 +1,7 @@
 @charset "utf-8";
 
 @import "variables";
+@import "variables_wp660";
 @import "ulitilies";
 @import "common";
 @import "common_margin-vertical";

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: kurudrive,vektor-inc,una9,sysbird,mtdkei
 Tested up to: 6.6
 Requires PHP: 7.4
-Stable tag: 1.26.1
+Stable tag: 1.26.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,6 +12,9 @@ The X-T9 is designed on the premise of full site editing function, and the user 
 GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
+
+1.26.2
+[ Design Bug Fix ] First aid for an issue where the value of --wp--preset--font-size--huge defined in theme.json is being overwritten by WordPress
 
 1.26.1
 [ Design Bug Fix ] Fixed the width of the post title on the edit screen

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: The X-T9 is designed on the premise of full site editing function, 
 Requires at least: 6.2
 Tested up to: 6.6
 Requires PHP: 7.4
-Version: 1.26.1
+Version: 1.26.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: x-t9


### PR DESCRIPTION
1. 新規固定ページを作成（タイトル入力のみ / 本文は未入力）
2. 公開画面で記事タイトルの文字が正常なのを確認
3. コードビューで以下のコードを入力して保存

```
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"primary"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-primary-background-color has-background wp-element-button">Fill Button</a></div>
<!-- /wp:button -->

<!-- wp:button {"textColor":"primary","className":"is-style-outline"} -->
<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-primary-color has-text-color wp-element-button">Outline Button</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```

4. 公開画面を見ると記事タイトルの文字サイズが 42px になる
5. このブランチに切り替えて npm run build
6. 公開画面を確認 -> 文字サイズが巨大になりすぎてない事を確認