### PR TITLE
 [ Design Bug Fix ] Fixed an issue where the wide block was aligned to the left within the full-width cover block.

### DIFF
--- a/assets/_scss/_block_width.scss
+++ b/assets/_scss/_block_width.scss
@@ -1,5 +1,7 @@
-.alignfull,
-.vk_outer-width-full {
+:is( .alignfull,.vk_outer-width-full ) {
+	&  >  :where(.is-layout-constrained ) {
+		max-width: var(--wp--style--global--content-size);
+	}
 	// 直下でもconstrainedの中でも幅は同じ
 	&,
 	.is-layout-constrained & {

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Bug Fix ] Fixed an issue where the wide block was aligned to the left within the full-width cover block.
+
 1.26.5
 [ Design Bug Fix ][ WooCommerce ] Fixed an issue where the number was not displayed in the WooCommerce quantity input field.
 


### PR DESCRIPTION
■ Before
![スクリーンショット 2024-11-05 23 32 14](https://github.com/user-attachments/assets/aeda4883-14c7-4521-bd67-83cbd0695e37)

■ After
![スクリーンショット 2024-11-05 23 31 48](https://github.com/user-attachments/assets/5ceef765-3a45-4cce-84b5-02b462acfa1c)

```
<!-- wp:cover {"overlayColor":"pale-cyan-blue","isUserOverlayColor":true,"minHeight":50,"isDark":false,"align":"full","layout":{"type":"constrained"}} -->
<div class="wp-block-cover alignfull is-light" style="min-height:50px"><span aria-hidden="true" class="wp-block-cover__background has-pale-cyan-blue-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:columns {"align":"wide","style":{"border":{"width":"1px"}}} -->
<div class="wp-block-columns alignwide" style="border-width:1px"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>全幅カバー &gt; 幅広カラム</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit,</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, </p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns --></div></div>
<!-- /wp:cover -->
```