### PR TITLE
[navigation]コア CSS をオーバーライドするように調整しました(VK Pattern Library 用)

### DIFF
--- a/assets/_scss/_navigation.scss
+++ b/assets/_scss/_navigation.scss
@@ -75,35 +75,47 @@
 	border: none; // コアが border を付与してくるので打ち消す
 }
 
-.wp-block-navigation__responsive-container:not(.has-modal-open) {
-	.wp-block-navigation__submenu-container {
-		z-index: 99999; // .crolled-header-fixed specified z-index: 9999; so If less than 9999 that submenu loses to the fix header in the edit screen
+.wp-block-navigation__responsive-container{
+	&:not(.has-modal-open) {
+		.wp-block-navigation__submenu-container {
+			z-index: 99999; // .crolled-header-fixed specified z-index: 9999; so If less than 9999 that submenu loses to the fix header in the edit screen
 
-		.wp-block-navigation-item {
-			border-bottom: 1px solid var(--wp--preset--color--border-normal-darkbg);
-			&:hover {
-				background-color: var(--wp--preset--color--primary-hover);
+			.wp-block-navigation-item {
+				border-bottom: 1px solid var(--wp--preset--color--border-normal-darkbg);
+				&:hover {
+					background-color: var(--wp--preset--color--primary-hover);
+				}
+
+				&__content {
+					font-size: var(--wp--preset--font-size--x-small);
+					padding: 1em 1.5em;
+				}
 			}
-
-			&__content {
-				font-size: var(--wp--preset--font-size--x-small);
-				padding: 1em 1.5em;
+			
+			&.has-vk-color-primary-background-color{ // Adjusted to override WordPress core CSS. (for VK Pattern Library)
+				background-color: var(--wp--preset--color--primary);
+			}
+			
+		}
+		.wp-block-navigation__submenu-container{
+			&:where(:not(.has-background)) {
+				.wp-block-navigation-item {
+					background-color: var(--wp--preset--color--primary);
+				}
+			}
+			&:where(:not(.has-text-color)) {
+				.wp-block-navigation-item {
+					color: #fff; // No relation under Bright BG and Dark BG
+				}
+			}
+			&:where(.has-background){
+				padding:unset; // Cancel the padding added by the WordPress core
 			}
 		}
 	}
-	.wp-block-navigation__submenu-container{
-		&:where(:not(.has-background)) {
-			.wp-block-navigation-item {
-				background-color: var(--wp--preset--color--primary);
-			}
-		}
-		&:where(:not(.has-text-color)) {
-			.wp-block-navigation-item {
-				color: #fff; // No relation under Bright BG and Dark BG
-			}
-		}
-		&:where(.has-background){
-			padding:unset; // Cancel the padding added by the WordPress core
+	&.has-modal-open{ // Adjusted to override WordPress core CSS. (for VK Pattern Library)
+		&.has-background.has-vk-color-primary-background-color{
+			background-color: var(--wp--preset--color--primary);
 		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Bug Fix ][ navigation ] Adjusted to override the WordPress core CSS of wp-block-navigation__submenu-container when the .has-vk-color-primary-background-color class is assigned. (for VK pattern library)
+
 1.27.0
 [ Specification Change ] Added support for the "Writing Mode" option in Typography settings for WordPress 6.7.
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-patterns/issues/371#issuecomment-2467049040 の

> ### X-T9のキーカラー
>  VKパターンライブラリのパターンで、ナビゲーションの「サブメニューとオーバーレイ背景」をキーカラー、「サブメニューとオーバーレイテキスト」を白にした場合、X-T9テーマではul タグにhas-vk-color-primary-background-color が付与されるが、背景が負けて白になり、テキストは白なので見えない。
> ブロックの設定から設定し直すと問題なく色がつくので問題ないといえば問題ないけど、キーカラーが付くと白背景になるよりは良いかもしれない

▼こちらから症状が確認できます　メニューのサブメニューを展開してください。ナビゲーションの
[ ヘッダー_ミニマムな角丸](https://patterns.vektor-inc.co.jp/vk-patterns/11534/?view=x-t9)
[ ヘッダー_流れるバナー](https://patterns.vektor-inc.co.jp/vk-patterns/11542/?view=x-t9)

## どういう変更をしたか？

* このプルリクで変更した事を記載してください

VK パターンライブラリのヘッダーのパターンで、「サブメニューとオーバーレイ背景」をキーカラー、「サブメニューとオーバーレイテキスト」を白にした場合、X-T9テーマで貼り直した時に「キーカラー」の設定がLightningとは違うためナビゲーションの設定からクリアされてコア側の白背景色がついてしまうため、（ナビゲーションブロックの「サブメニューとオーバーレイ背景」から設定し直せば問題ないのですが、パターンライブラリのiframe内で白くなるのが気になるため）cssを追加しました。

#### ▼修正前
![スクリーンショット 2024-11-20 18 51 35](https://github.com/user-attachments/assets/77fbf2d2-5cd3-4e48-8030-3ef198bfa4c9)


#### ▼修正後

![スクリーンショット 2024-11-20 18 50 41](https://github.com/user-attachments/assets/16bb6335-0f06-455b-a014-73fc3c683ca1)

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？
CSSの修正のため書いていません

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

[ ヘッダー_ミニマムな角丸](https://patterns.vektor-inc.co.jp/vk-patterns/11534/)
- テーマはX-T9のmasterブランチの環境で上記のヘッダーパターンをコピペする。
- ナビゲーションのメニューには、サブメニューが展開するメニューをセットして、背景色が白くなっていることを確認。
- このブランチに変更して、PCサイズでメニューからサブメニューを展開した時にキーカラーが付いていることを確認し、次にスマホサイズでハンバーガーメニューを押した時に背景色にキーカラーがついていることを確認しました。

## レビュワーの確認方法・確認する内容など

[ ヘッダー_ミニマムな角丸](https://patterns.vektor-inc.co.jp/vk-patterns/11534/)
- VK Blocks プラグインを有効にして、テーマはX-T9のmasterブランチの環境で上記のヘッダーパターンをコピペする。
[X-T9のナビゲーションの設定についてはこちらをご確認ください](https://training.vektor-inc.co.jp/courses/x-t9-basic-settings/lessons/x-t9-navigation-setting/)
- ナビゲーションのメニューには、サブメニューが展開するメニューをセットして、背景色が白くなっていることを確認。
- このブランチに変更して` npm run build` し、PCサイズでメニューからサブメニューを展開した時にキーカラーが付いていることを確認し、次にスマホサイズでハンバーガーメニューを押した時に背景色にキーカラーがついていることを確認してください。

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
