### PR TITLE
全幅の中のis-layout-constrainedが中央寄せになるように

### DIFF
--- a/assets/_scss/_block_width.scss
+++ b/assets/_scss/_block_width.scss
@@ -1,6 +1,8 @@
 :is( .alignfull,.vk_outer-width-full ) {
 	&  >  :where(.is-layout-constrained ) {
 		max-width: var(--wp--style--global--content-size);
+		margin-left: auto;
+		margin-right: auto;
 	}
 	// 直下でもconstrainedの中でも幅は同じ
 	&,

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Bug Fix ] Fixed an issue where constrained blocks were misaligned inside full-width blocks.
 [ Design Bug Fix ][ navigation ] Adjusted to override the WordPress core CSS of wp-block-navigation__submenu-container when the .has-vk-color-primary-background-color class is assigned. (for VK pattern library)
 
 1.27.0


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-patterns/issues/371#issuecomment-2492995960

## どういう変更をしたか？

* このプルリクで変更した事を記載してください

全幅のグループブロック内に通常幅のグループブロックを入れた場合(コンテナ内に収めるためのクラス名 `is-layout-constrained`がつく )に左側に寄ってしまうため、`margin`の左右に`auto`を追加しました

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？　CSSのみなのでスキップ

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど
* テーマをX-T9にして、以下のフッターのパターンを、エディタ > パターン > フッター のところに貼り付ける。
（確認するだけなので、2個一気に貼り付けていただいてoKです）
[フッター 白背景センター配置](https://patterns.vektor-inc.co.jp/vk-patterns/footer-center-bg-white/)
[フッター アイコン背景](https://patterns.vektor-inc.co.jp/vk-patterns/11576/)

* `master` のブランチで、フロント画面で左に寄っていることを確認して、このブランチに切り替え、`npm run build` をして、中央によっていることを確認しました。

## レビュワーの確認方法・確認する内容など

実装者と同じ確認方法でお願いします

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
