### PR TITLE
[ navigation ][ fix ] 編集画面でのナビゲーションのGap指定削除

### DIFF
--- a/assets/_scss/editor-wp65.scss
+++ b/assets/_scss/editor-wp65.scss
@@ -59,11 +59,3 @@
 .is-layout-constrained>.wp-block-spacer+* {
 	margin-block-start: 0;
 }
-
-// Navigation -------------------------------------------------
-
-// overwrite .editor-styles-wrapper .is-layout-flex { gap: var(--wp--custom--spacing--small); } on editor
-.wp-block-navigation>.wp-block-navigation__container,
-.wp-block-navigation__responsive-container-content .wp-block-navigation__container {
-	gap: 0;
-}

--- a/assets/_scss/editor.scss
+++ b/assets/_scss/editor.scss
@@ -59,11 +59,3 @@
 .is-layout-constrained>.wp-block-spacer+* {
 	margin-block-start: 0;
 }
-
-// Navigation -------------------------------------------------
-
-// overwrite .editor-styles-wrapper .is-layout-flex { gap: var(--wp--custom--spacing--small); } on editor
-.wp-block-navigation>.wp-block-navigation__container,
-.wp-block-navigation__responsive-container-content .wp-block-navigation__container {
-	gap: 0;
-}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/x-t9/pull/245

編集画面でナビゲーションブロックの間隔指定が効かない

## どういう変更をしたか？

編集画面でナビゲーションブロックに対して gap:0; 指定がしてあった。
おそらく旧バージョンのWordPressでは共有のgapが自動的についてしまっていたために、それを打ち消す目的で追加したものと思われる。
しかしながら、現行バージョンでは左右の gap は0指定がなくてもつかなくなり、不要となったため削除
