### PR TITLE
[ Design Bug Fix ] Fix an issue where the CSS is not applied when the navigation is set to always display

### DIFF
--- a/assets/_scss/_navigation.scss
+++ b/assets/_scss/_navigation.scss
@@ -1,4 +1,4 @@
-/* 
+/****************************************************** 
  * Navigation Styles
  */
 
@@ -68,14 +68,14 @@
 	}
 }
 
-/* 
+/****************************************************** 
  * Sub Navigation Styles
  */
 .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
 	border: none; // コアが border を付与してくるので打ち消す
 }
 
-.wp-block-navigation__responsive-container{
+.wp-block-navigation {
 	&:not(.has-modal-open) {
 		.wp-block-navigation__submenu-container {
 			z-index: 99999; // .crolled-header-fixed specified z-index: 9999; so If less than 9999 that submenu loses to the fix header in the edit screen

--- a/assets/_scss/_navigation.scss
+++ b/assets/_scss/_navigation.scss
@@ -24,7 +24,7 @@
 	}
 
 	// PC Menu style
-	&__responsive-container:where(:not(.has-modal-open)) {
+	&:where(:not(.has-modal-open)) {
 
 		// :where(.wp-block-navigation__container, 
 		// .wp-block-page-list) {

--- a/assets/_scss/_navigation_additional-class.scss
+++ b/assets/_scss/_navigation_additional-class.scss
@@ -50,8 +50,7 @@
  * active-border-bottom
  */
 
-*[class*='nav--active-border-bottom'] {
-	.wp-block-navigation__responsive-container:where(:not(.is-menu-open)) {
+ .wp-block-navigation[class*='nav--active-border-bottom']:where(:not(.is-menu-open)) {
 		:where(.wp-block-navigation__container, .wp-block-page-list) {
 			&>.wp-block-navigation-item {
 				&>a {
@@ -77,7 +76,6 @@
 				}
 			}
 		}
-	}
 }
 
 /******************************************************

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
-[ Design Bug Fix ] Fix an issue where the CSS for submenus is not applied when the navigation overlay menu is set to off.
+[ Design Bug Fix ] Fix an issue where the CSS is not applied when the navigation is set to always display.
 
 1.27.1
 [ Design Bug Fix ] Fixed an issue where constrained blocks were misaligned inside full-width blocks.

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Bug Fix ] Fix an issue where the CSS for submenus is not applied when the navigation is set to always display.
+
 1.27.1
 [ Design Bug Fix ] Fixed an issue where constrained blocks were misaligned inside full-width blocks.
 [ Design Bug Fix ][ navigation ] Adjusted to override the WordPress core CSS of wp-block-navigation__submenu-container when the .has-vk-color-primary-background-color class is assigned. (for VK pattern library)

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
-[ Design Bug Fix ] Fix an issue where the CSS for submenus is not applied when the navigation is set to always display.
+[ Design Bug Fix ] Fix an issue where the CSS for submenus is not applied when the navigation overlay menu is set to off.
 
 1.27.1
 [ Design Bug Fix ] Fixed an issue where constrained blocks were misaligned inside full-width blocks.


### PR DESCRIPTION
ナビゲーションのオーバーレイをオフにするとスタイルがいくつか適用されなくなる不具合を修正

## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

ナビゲーションのオーバーレイをオフに指定すると...

* サブメニューアイテムの余白があたらなくなる
* メインメニューアイテムのサブメニューアイコンの右側の余白があたらなくなる
* アクティブボーターボドムのスタイルが当たらなくなる

★ ナビゲーションオーバーレイをオフにする事によって dom / クラス名 が変動する事を想定されていなかった

■ Before
![スクリーンショット 2024-12-07 22 53 49](https://github.com/user-attachments/assets/0bba5d93-b670-4300-969a-d47e82d57a2e)

## どういう変更をしたか？

もとが .wp-block-navigation__responsive-container に対してCSSがついていたが、
オーバーレイがオフだとこのクラス名はつかないので対象セレクタを変更

■ After

![スクリーンショット 2024-12-07 22 52 50](https://github.com/user-attachments/assets/2f1a7194-d37b-4cd8-9e7a-ac80ed74d9ee)


#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

## レビュワーの確認方法・確認する内容など

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
