### PR TITLE
PaginationのPrev、Nextボタンに余白を追加して調整

### DIFF
--- a/assets/_scss/_pagenation.scss
+++ b/assets/_scss/_pagenation.scss
@@ -19,21 +19,17 @@
 		}
 	}
 
-	&-numbers {
-		+ .wp-block-query-pagination-next {
-			margin-inline-start: .5em;
-		}
-	}
-
-	&-previous {
-		+ .wp-block-query-pagination-numbers {
-			margin-inline-start: .5em;
-		}
-	}
-
 	.page-numbers.current {
 		color: var(--wp--preset--color--text-normal);
 		background-color: var(--wp--preset--color--bg-light-gray);
 		border: 1px solid var(--wp--preset--color--border-normal);
+	}
+
+	.wp-block-query-pagination-next {
+		margin-inline-start: .5em;
+	}
+
+	.wp-block-query-pagination-previous {
+		margin-inline-end: .5em;
 	}
 }

--- a/assets/_scss/_pagenation.scss
+++ b/assets/_scss/_pagenation.scss
@@ -9,7 +9,6 @@
 	&-next {
 		line-height: 1;
 		padding: 10px 1em;
-		margin-right:0.5em;
 		background-color: var(--wp--preset--color--primary);
 		&:hover {
 			background-color: var(--wp--preset--color--primary-hover);
@@ -17,6 +16,18 @@
 		:root & {
 			text-decoration: none;
 			color: #fff; // BG Secondary and Dark both white
+		}
+	}
+
+	&-numbers {
+		+ .wp-block-query-pagination-next {
+			margin-inline-start: .5em;
+		}
+	}
+
+	&-previous {
+		+ .wp-block-query-pagination-numbers {
+			margin-inline-start: .5em;
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -15,6 +15,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 [ Specification Change ] Some measurement units have been removed.
 [ Design Bug Fix ] Fix an issue where the CSS is not applied when the navigation is set to always display.
+[ Design Bug Fix ] Add margin to pagination previous and next buttons.
 
 1.27.1
 [ Design Bug Fix ] Fixed an issue where constrained blocks were misaligned inside full-width blocks.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: kurudrive,vektor-inc,una9,sysbird,mtdkei
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable tag: 1.27.0
+Stable tag: 1.27.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+1.27.1
 [ Design Bug Fix ] Fixed an issue where constrained blocks were misaligned inside full-width blocks.
 [ Design Bug Fix ][ navigation ] Adjusted to override the WordPress core CSS of wp-block-navigation__submenu-container when the .has-vk-color-primary-background-color class is assigned. (for VK pattern library)
 

--- a/style.css
+++ b/style.css
@@ -4,10 +4,10 @@ Theme URI: https://github.com/vektor-inc/x-t9
 Author: Kurudrive
 Author URI: https://www.vektor-inc.co.jp/
 Description: The X-T9 is designed on the premise of full site editing function, and the user can flexibly customize the header, footer, etc. This theme is mainly intended for use on business sites.
-Requires at least: 6.3
+Requires at least: 6.5
 Tested up to: 6.7
 Requires PHP: 7.4
-Version: 1.27.0
+Version: 1.27.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: x-t9


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
 X-T9 PaginationのNextボタンに余白がありませんので修正 #312 
 を引き継いでいます

## どういう変更をしたか？
* Prev ボタンの右、Next ボタンの左に余白がないので追加しました
![pagenation](https://github.com/user-attachments/assets/e425d8f3-26ff-4a81-af90-b9240f172e64)

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

## レビュワーの確認方法・確認する内容など
* ページネーションで Prev ボタンと数字の間、数字と Next ボタンの間に余白がなくくっついていたので、余白が空くようになったか確認お願いします
* 下記が気になってるのでご意見もらえますか
  * コアのCSS が強いため SCSS の記述がおかしい(やっつけ感アリ)かもしれない、適切な書き方がありましたらご指摘ください
  * 今回 0.5em の余白を追加したが、数字と数字の間は `<br>`で空いているため微妙に空き具合が異なる、よい方法あったらご指摘ください


## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
