### PR TITLE
[ nav ] active border class が編集画面でいろいろ効かない不具合を修正

### DIFF
--- a/assets/_scss/_navigation_additional-class.scss
+++ b/assets/_scss/_navigation_additional-class.scss
@@ -52,7 +52,7 @@
 
  .wp-block-navigation[class*='nav--active-border-bottom'] {
 	// Overlay : mobile ( Wide screen )
-	.wp-block-navigation__responsive-container:not(.has-modal-open) .wp-block-navigation__responsive-container-content > ul,
+	.wp-block-navigation__responsive-container:not(.has-modal-open) .wp-block-navigation__responsive-container-content > .wp-block-navigation__container,
 	// Overlay : off（ It is now positioned directly below .wp-block-navigation. ）
 	& > :where( .wp-block-navigation__container, .wp-block-page-list ) {
 			&>.wp-block-navigation-item {


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

オーバーレイ : モバイル / スタイル : アクティブボーダー
の設定の時に編集画面でアクティブボーダーのスタイルが当たらない
ただし、この変更は 1.27.1 以降の変更に起因するので、 readme などには記載しない

## どういう変更をしたか？

公開画面側のナビゲーションは ul.wp-block-navigation__container だが、
編集画面は div.wp-block-navigation__container なので、

ul に対してではなく .wp-block-navigation__container 指定に変更