### PR TITLE
[ Specification Change ] Update theme.json to V3 from V2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Specification Change ] Update theme.json to V3
+
 1.29.0
 [ Specification Change ( Redesign ) ][ Navigation ] Refactoring the design of the navigation block.
 [ Bug fix ] Fixed an issue with full-width processing in the editor.

--- a/theme.json
+++ b/theme.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/theme.json",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"layout": {
 			"contentSize": "var(--wp--custom--width--content)",
@@ -87,6 +87,7 @@
 			"customDuotone": true
 		},
 		"spacing": {
+			"defaultSpacingSizes": false,
 			"blockGap": true,
 			"margin": true,
 			"padding": true,
@@ -154,6 +155,7 @@
 			"lineHeight": true,
 			"fluid": false,
 			"writingMode": true,
+			"defaultFontSizes": false,
 			"fontFamilies": [
 				{
 					"slug": "system-font",


### PR DESCRIPTION
theme.json の新しいバージョンへの移行
https://ja.wordpress.org/team/handbook/block-editor/reference-guides/theme-json-reference/theme-json-migrations/

theme.json Version 3 リファレンス (最新)
https://ja.wordpress.org/team/handbook/block-editor/reference-guides/theme-json-reference/theme-json-living/