### PR TITLE
[ Specification Change ] Add styles setting in syles json

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 == Changelog ==
 
 [ Specification Change ] Update theme.json to V3
+[ Specification Change ] Add styles setting in syles json
 
 1.29.0
 [ Specification Change ( Redesign ) ][ Navigation ] Refactoring the design of the navigation block.

--- a/styles/bg-black.json
+++ b/styles/bg-black.json
@@ -1,6 +1,6 @@
 {
-	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/theme.json",
-	"version": 2,
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 3,
 	"title": "BG Black",
 	"settings": {
 		"color": {
@@ -61,6 +61,11 @@
 					"name": "Border Normal (Dark BG)"
 				}
 			]
+		}
+	},
+	"styles": {
+		"typography": {
+			"fontFamily": "var:preset|font-family|system-font"
 		}
 	}
 }

--- a/styles/red.json
+++ b/styles/red.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/theme.json",
-	"version": 2,
+	"version": 3,
 	"title": "Red",
 	"settings": {
 		"color": {
@@ -61,6 +61,11 @@
 					"name": "Border Normal (Dark BG)"
 				}
 			]
+		}
+	},
+	"styles": {
+		"typography": {
+			"fontFamily": "var:preset|font-family|system-font"
 		}
 	}
 }

--- a/styles/red.json
+++ b/styles/red.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/theme.json",
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 3,
 	"title": "Red",
 	"settings": {

--- a/styles/sweet.json
+++ b/styles/sweet.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/theme.json",
-	"version": 2,
+	"version": 3,
 	"title": "Sweet",
 	"settings": {
 		"color": {
@@ -61,6 +61,11 @@
 					"name": "Border Normal (Dark BG)"
 				}
 			]
+		}
+	},
+	"styles": {
+		"typography": {
+			"fontFamily": "var:preset|font-family|system-font"
 		}
 	}
 }

--- a/styles/sweet.json
+++ b/styles/sweet.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/theme.json",
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 3,
 	"title": "Sweet",
 	"settings": {


### PR DESCRIPTION
## 変更の理由

外観 > エディタで スタイル（修正後の状態）が出なくなった。
これは WordPress が パレットやタイポグラフィのセットが追加できるようになったので、従来のスタイル指定のjsonには色しか指定してなかったのでパレット扱いにされたのだと思われる。

個人的には実際パレットしか指定してないので既存でいいのだが、初心者本がスタイルでの表記になってるため問い合わせが多いらしいので、スタイル表示にするために実際はどうでもいいが font の情報を追加

■ Before
![スクリーンショット 2025-01-04 23 21 26](https://github.com/user-attachments/assets/6032fa8e-01e2-46ff-a04a-d67d3776755a)

■ After
![スクリーンショット 2025-01-04 23 19 51](https://github.com/user-attachments/assets/1e7d7a37-ef72-4ebc-9e93-f797b0c34f11)
