### PR TITLE
[ Specification Change / Bug fix ] Add z-index:9999 to footer.wp-block-template-part

### DIFF
--- a/assets/_scss/_footer.scss
+++ b/assets/_scss/_footer.scss
@@ -5,4 +5,5 @@ html {
 footer.wp-block-template-part {
 	position: sticky;
 	top: 100vh;
+	z-index:9999;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Specification Change / Bug fix ] Add z-index:9999 to footer.wp-block-template-part
+
 1.30.0
 [ Specification Change ] Update theme.json to V3
 [ Specification Change ] Add styles setting in syles json


### PR DESCRIPTION
■ Before
![スクリーンショット 2025-01-15 15 53 57](https://github.com/user-attachments/assets/f976b770-1cd6-468d-91cc-50909e16fac4)


■ After
![スクリーンショット 2025-01-15 15 54 29](https://github.com/user-attachments/assets/9ba1c1c7-8e76-4226-85e2-7c7f040076ef)
