### PR TITLE
[ 不具合修正 ] スライダーアイテムブロックの中に画像ブロックを配置して中央揃えにしても中央にならない不具合を修正

### DIFF
--- a/assets/_scss/_common.scss
+++ b/assets/_scss/_common.scss
@@ -44,6 +44,12 @@ img {
 figure {
 	max-width: 100%;
 	margin: 0;
+	// WP 6.7.2 の時点で、スライダーアイテムブロックの中に画像を配置した場合に中央寄せが効かないため
+	// At WP 6.7.2, the image in the slider item block does not center align
+	&.aligncenter {
+		margin-left:auto;
+		margin-right:auto;
+	}
 }
 
 main {

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Bug fix ] Fix an issue where image block align center dosen't work when put into the slider item block.
+
 1.31.0
 [ Other ] Cope with menu item description HTML
 [ Specification Change / Bug fix ] Add z-index:9999 to footer.wp-block-template-part


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

![スクリーンショット 2025-03-31 19 51 01](https://github.com/user-attachments/assets/ac37c34f-a76f-4ee4-b865-22b744d302de)
