### PR TITLE
【確認待ち】[ その他 ][ 6.8対応 ] ナビゲーションブロックにおける current-menu-ancestor CSS クラス適用の修正

### DIFF
--- a/assets/_scss/_navigation_additional-class.scss
+++ b/assets/_scss/_navigation_additional-class.scss
@@ -71,9 +71,7 @@
 					position: absolute;
 					border-bottom: 2px solid var(--wp--preset--color--primary);
 				}
-				// current-menu-item は li に付与されるのに、
-				// current-menu-ancestor は a に付与されるので注意...
-				&> :is(a:hover, .current-menu-item > a, .current-menu-ancestor) {
+				&> :is(a:hover, .current-menu-item > a, .current-menu-ancestor > a) {
 					&::after {
 						width: 100%;
 					}

--- a/assets/_scss/_navigation_additional-class.scss
+++ b/assets/_scss/_navigation_additional-class.scss
@@ -71,7 +71,8 @@
 					position: absolute;
 					border-bottom: 2px solid var(--wp--preset--color--primary);
 				}
-				&> :is(a:hover, .current-menu-item > a, .current-menu-ancestor > a) {
+				// ↓ .current-menu-ancestor は WP6.8になったら a に付与されるので削除
+				&> :is(a:hover, .current-menu-item > a, .current-menu-ancestor > a, .current-menu-ancestor) {
 					&::after {
 						width: 100%;
 					}

--- a/assets/_scss/_navigation_additional-class.scss
+++ b/assets/_scss/_navigation_additional-class.scss
@@ -71,7 +71,8 @@
 					position: absolute;
 					border-bottom: 2px solid var(--wp--preset--color--primary);
 				}
-				// ↓ .current-menu-ancestor は WP6.8になったら a に付与されるので削除
+				// .current-menu-ancestor は WP6.8になったら a に付与されるので追加
+				// :isの中の .current-menu-ancestor は WP6.8が安定したら削除
 				&> :is(a:hover, .current-menu-item > a, .current-menu-ancestor > a, .current-menu-ancestor) {
 					&::after {
 						width: 100%;

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Other ][ 6.8 ] Fix current menu ancestor CSS class application for Navigation Block in WP6.6.
+
 1.31.1
 [ Bug fix ] Fix an issue where image block align center dosen't work when put into the slider item block.
 

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
-[ Other ][ 6.8 ] Fix current menu ancestor CSS class application for Navigation Block in WP6.6.
+[ Other ][ 6.8 ] Fix current menu ancestor CSS class application for Navigation Block in WP6.8.
 
 1.31.1
 [ Bug fix ] Fix an issue where image block align center dosen't work when put into the slider item block.


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://make.wordpress.org/core/2025/03/25/miscellaneous-block-editor-changes-in-wordpress-6-8/
の Consistent Class Application for Navigation Block Menu Items

## どういう変更をしたか？

WordPress 6.8から、current-menu-ancestor クラスが <li> 要素ではなく、<a> 要素に適用されるようになったため、CSSを追加しました。
6.8が配信されしばらく経った後に`.current-menu-ancestor`の記述を削除するようコメントアウトで書いてあります。

お一人確認で大丈夫かと思いますが何かありましたら二人目に回してください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？ →CSSを調整しただけなのでスキップ。

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. WordPress 6.7でナビゲーションブロックを使用して親子関係のあるメニューを作成しフロントエンドに表示されるよう配置
2. フロントエンドで1のメニューを確認し、親ページにオンマウスし子ページをクリックして子ページ開く
3. 子ページを開いたときに、子ページの親であるメニュー名に下線が適用されていることを確認
4. WordPress6.8に切り替えた際も子ページの親であるメニュー名に下線が適用されていることを確認

## レビュワーの確認方法・確認する内容など

上記と同じ確認を行ってください。

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
