### PR TITLE
6.8 RC でナビゲーションディスクリプションが２重で表示される不具合を修正

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -156,6 +156,9 @@ function xt9_add_description_to_navigation_items( $block_content, $block ) {
 	}
 	return $block_content;
 }
-if ( version_compare( get_bloginfo( 'version' ), '6.8', '<' ) ) {
+$version = get_bloginfo('version');
+if ( version_compare( preg_replace('/[^0-9.]/', '', $version), '6.8', '<' ) ) {
+	// 6.8 未満で実行（ 6.8 RC版やBeta版も除外 ）
+	// Run with a version earlier than 6.8 (excluding 6.8 RC and Beta versions)
     add_filter( 'render_block', 'xt9_add_description_to_navigation_items', 10, 2 );
 }

--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 == Changelog ==
 
 [ Other ][ 6.8 ] Fix current menu ancestor CSS class application for Navigation Block in WP6.8.
+[ Other ][ 6.8 ] The description display process was set to run on versions earlier than 6.8, but it was also running on 6.8 RC. Therefore, it has been modified so that it no longer runs on 6.8 RC.
 
 1.31.1
 [ Bug fix ] Fix an issue where image block align center dosen't work when put into the slider item block.


### PR DESCRIPTION
The description display process was set to run on versions earlier than 6.8, but it was also running on 6.8 RC. Therefore, it has been modified so that it no longer runs on 6.8 RC.

■ Before
![スクリーンショット 2025-04-10 12 16 41](https://github.com/user-attachments/assets/baa62155-5cd6-45b9-bc86-5e76909b7434)
