### PR TITLE
[ 不具合修正 ] ホームテンプレートの初期状態で文字が改行されてる＆右に寄っている不具合を修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -17,6 +17,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 [ Specification Change ][ Search button ] Add nowrap and padding tuning
 [ Specification Change ] Social media links in the header and footer block patterns now open in a separate tab by default.
 [ Specification Change ] Make adjustments to the CSS of the core/post-terms block.
+[ Bug fix ] Fix unintentional br and indent in the page header of the home template
 [ Other ] Update anchor link CSS
 
 1.33.0

--- a/templates/home.html
+++ b/templates/home.html
@@ -13,8 +13,7 @@
 			<!-- /wp:spacer -->
 
 			<!-- wp:heading {"textAlign":"center","level":1,"textColor":"text-normal","className":"has-bg-light-gray-background-color"} -->
-			<h1 class="has-text-align-center has-bg-light-gray-background-color has-text-normal-color has-text-color">
-				Information</h1>
+			<h1 class="has-text-align-center has-bg-light-gray-background-color has-text-normal-color has-text-color">Information</h1>
 			<!-- /wp:heading -->
 
 			<!-- wp:spacer {"className":"is-style-spacer-md"} -->


### PR DESCRIPTION
■ Before
![スクリーンショット 2025-06-12 2 57 21](https://github.com/user-attachments/assets/c31e2dc8-dc79-4118-b930-4fda473a00db)

■ After
![スクリーンショット 2025-06-12 2 56 53](https://github.com/user-attachments/assets/181b6e32-0a3f-4df2-b224-eac35ef81024)
