### PR TITLE
[ Specification Change ] Abolished the loop-archive template

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Specification Change ] Abolished the loop-archive template
 [ Specification Change ] Add color palette and secondary color
 [ Specification Change ][ Typography ] Add Serif font and Serif font preset
 [ Specification Change ][ Typography ] Add text-box: trim-both text;

--- a/templates/home.html
+++ b/templates/home.html
@@ -36,7 +36,7 @@
 	<div class="wp-block-columns is-style-main-layout">
 		<!-- wp:column -->
 		<div class="wp-block-column">
-			<!-- wp:template-part {"slug":"loop-archive","tagName":"div"} /-->
+			<!-- wp:pattern {"slug":"x-t9/query-image-left"} /-->
 		</div>
 		<!-- /wp:column -->
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,7 +34,8 @@
 
 	<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|70","left":"var:preset|spacing|70"}}},"className":"is-style-main-layout"} -->
 	<div class="wp-block-columns is-style-main-layout"><!-- wp:column -->
-		<div class="wp-block-column"><!-- wp:template-part {"slug":"loop-archive","tagName":"div"} /-->
+		<div class="wp-block-column">
+			<!-- wp:pattern {"slug":"x-t9/query-image-left"} /-->
 		</div>
 		<!-- /wp:column -->
 

--- a/templates/search.html
+++ b/templates/search.html
@@ -32,7 +32,7 @@
 	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 	<!-- /wp:spacer -->
 
-	<!-- wp:template-part {"slug":"loop-archive","tagName":"div"} /-->
+	<!-- wp:pattern {"slug":"x-t9/query-image-left"} /-->
 
 	<!-- wp:spacer {"className":"is-style-spacer-xl"} -->
 	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>

--- a/theme.json
+++ b/theme.json
@@ -452,7 +452,7 @@
 		},
 		{
 			"name": "loop-archive",
-			"title": "Loop Archive",
+			"title": "Loop Archive ( Deprecated )",
 			"area": "uncategorized"
 		},
 		{


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/x-t9/issues/347

loop-archive テンプレートパーツを編集しようとしてクエリを改変されると、検索結果ページなど他のページでも影響を受けてしまうため

## どういう変更をしたか？

テンプレートパーツ loop-archive として読み込んでいたものを非同期パターンに変更