### PR TITLE
[ 仕様変更 ] 投稿サブコンテンツパターンの上下揃えを中央から上に変更

### DIFF
--- a/inc/patterns/footer/footer-bg-dark-3col.php
+++ b/inc/patterns/footer/footer-bg-dark-3col.php
@@ -58,7 +58,7 @@ return array(
 	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xs"></div>
 	<!-- /wp:spacer -->
 	
-	<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+	<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
 	<div class="wp-block-group"><!-- wp:post-featured-image {"width":"60px","height":"60px"} /-->
 	
 	<!-- wp:group {"layout":{"type":"default"}} -->

--- a/inc/patterns/footer/footer-bg-secondary-3col.php
+++ b/inc/patterns/footer/footer-bg-secondary-3col.php
@@ -58,7 +58,7 @@ return array(
 	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xs"></div>
 	<!-- /wp:spacer -->
 	
-	<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+	<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
 	<div class="wp-block-group"><!-- wp:post-featured-image {"width":"60px","height":"60px"} /-->
 	
 	<!-- wp:group {"layout":{"type":"default"}} -->

--- a/inc/patterns/post-template-subcontent.php
+++ b/inc/patterns/post-template-subcontent.php
@@ -13,7 +13,7 @@ return array(
 	<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xs"></div>
 	<!-- /wp:spacer -->
 	
-	<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+	<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
 	<div class="wp-block-group"><!-- wp:post-featured-image {"width":"60px","height":"60px"} /-->
 	
 	<!-- wp:group {"layout":{"type":"default"}} -->

--- a/readme.txt
+++ b/readme.txt
@@ -18,6 +18,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 [ Specification Change ][ Search button ] Add nowrap and padding tuning
 [ Specification Change ] Social media links in the header and footer block patterns now open in a separate tab by default.
 [ Specification Change ] Make adjustments to the CSS of the core/post-terms block.
+[ Specification Change ][ Post subcontent Pattern ] Change to vertical align top.
 [ Bug fix ][ Header Pattern ] Fixed an issue where there was no top margin above the mobile menu toggle button.
 [ Bug fix ] Fix unintentional br and indent in the page header of the home template
 [ Other ] Update anchor link CSS


### PR DESCRIPTION
■ Before
![スクリーンショット 2025-06-17 0 25 17](https://github.com/user-attachments/assets/4d16cc3b-e490-4d0b-bca1-3deca0e10146)

■ After
![スクリーンショット 2025-06-17 0 23 02](https://github.com/user-attachments/assets/edb2f9b4-2770-420e-940d-2d0dffb4b6ea)
