### PR TITLE
[ 不具合修正 ][ フッター ] ヘッダーに被らないようにフッターのz-indexを下げました

### DIFF
--- a/assets/_scss/_footer.scss
+++ b/assets/_scss/_footer.scss
@@ -5,5 +5,5 @@ html {
 footer.wp-block-template-part {
 	position: sticky;
 	top: 100vh;
-	z-index:9999;
+	z-index:9998;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Bug fix ] To prevent the footer and header from overlapping, I changed the z-index of the footer from 9999 to 9998.
 [ Specification Change ][ Navigation ] Text alignment is no longer affected by the navigation block's alignment setting. Previously, text alignment would follow the block's position, but this behavior has been disabled. / For horizontally aligned navigation blocks, only the first-level items are now center-aligned.
 [ Specification Change ][ Navigation ] Changed the mobile menu toggle to use the "Menu" icon.
 [ Specification Change ][ Search button ] Add nowrap and padding tuning


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/issues/assigned?issue=vektor-inc%7Cx-t9%7C363

## どういう変更をしたか？
ヘッダーとフッターのz-indexがどちらも9999になっていて、重なった時フッターが上にきます。
ヘッダーが上に来るようにフッターのz-indexを9998にしました。

ヘッダーを10000にしても良いかと思ったのですが、ライトボックス系のプラグインが9999になってることが多いので、9998にしています。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [x] 書けそうなテストは書いたか？
  CSSの変更なのでパス

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど
デベロッパーツールでフッターにz-index:9998が当たっている事を確認しました。
フッターとヘッダーを重ねる為にフッターに高さを付け(長いテキストを入れました)、ヘッダーが上に来ることを確認しました。

## レビュワーの確認方法・確認する内容など
実装者と同じ

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
