### PR TITLE
【確認待ち】[ 不具合修正 ] フッターに配置したメニューがモーダルになった時にヘッダーの下に埋まる不具合を修正

### DIFF
--- a/assets/_scss/_footer.scss
+++ b/assets/_scss/_footer.scss
@@ -5,5 +5,13 @@ html {
 footer.wp-block-template-part {
 	position: sticky;
 	top: 100vh;
+	// scrolled-header-fixed は 9999 になっている
+	// フッター要素が固定ヘッダーの上にならないように 9998 にしておく
+	// scrolled-header-fixed is 9999, so set 9998 to avoid footer element on fixed header.
 	z-index:9998;
+	// モーダルが固定ヘッダーの下にならないように、開いてる時は 9999 に指定
+	// to avoid modal element on fixed header, set 9999 when modal is open.
+	html.has-modal-open & {
+		z-index:9999;
+	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Bug fix ] Fix an issue where the footer menu, when displayed as a modal, gets hidden underneath the header.
+
 1.34.0
 [ Specification Change ][ Color palette ] Add color palette and Complementary color
 [ Specification Change ][ Color palette ] Add color palette Foresty


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

フッターの z-index をhttps://github.com/vektor-inc/x-t9/pull/364 で上げた事により、フッターに配置したモーダルメニューが固定ヘッダーの下になり、閉じるボタンが押せなくなってしまった。

## どういう変更をしたか？

モーダルが開いている時にフッターの z-index を上げる

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

* npm run build
* フッターのメニューにモバイルで開いて、ヘッダーに埋まらない事を確認

## レビュワーの確認方法・確認する内容など

実装者に同じ

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
