### PR TITLE
[ 不具合修正 ] コンテンツ幅の投稿コンテンツ直下に幅広要素を配置した場合に、中央にならない不具合を修正

### DIFF
--- a/assets/_scss/_block_width.scss
+++ b/assets/_scss/_block_width.scss
@@ -29,7 +29,8 @@
 	// （全幅や幅広のブロックのインナーコンテナの時点ではコンテンツ幅になっていないのでマイナスオフセットする必要がない）
 	:where(:not(:is(.alignfull, .alignwide))) > .is-layout-constrained[class*="__inner-container"] > &, 
 	// .is-layout-constrained > の中の要素（コンテンツ幅） > の中に幅広を配置された場合
-	.is-layout-constrained:where(:not(:is(.alignfull, .alignwide)))> :where(:not(:is(.alignfull, .alignwide))) > & {
+	// ※ 2階層目がコンテンツ幅なので、最初の .is-layout-constrained の要素は alignll でも alignwide でも関係ない
+	.is-layout-constrained > :where(:not(:is(.alignfull, .alignwide))) > & {
 		margin-left: calc((100% - var(--wp--custom--width--wrapper)) / 4) !important;
 		margin-right: calc((100% - var(--wp--custom--width--wrapper)) / 4) !important;
 		&.wp-block-image {

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Bug fix ] Fix an issue where an alignwide element placed directly under post content with a specified content width is not centered properly.
+
 1.34.1
 [ Specification Change ][ Navigation ] Changed the footer mobile menu toggle to use the "Menu" icon.
 [ Bug fix ] Fix an issue where the footer menu, when displayed as a modal, gets hidden underneath the header.


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

■ Before
![スクリーンショット 2025-07-10 17 14 11](https://github.com/user-attachments/assets/a319934c-154c-433e-9d66-369f2c6cf447)

■ After
![スクリーンショット 2025-07-10 17 13 18](https://github.com/user-attachments/assets/675924f4-1bd7-4066-85f9-f8b718c02e04)

