### PR TITLE
[ 不具合修正 ] Windows端末でブロックの入れ子の状態によってはレイアウトが崩れる不具合を修正

### DIFF
--- a/assets/_scss/_block_width.scss
+++ b/assets/_scss/_block_width.scss
@@ -6,7 +6,12 @@
 	// 直下でも constrained の中でも幅は同じ
 	&,
 	.is-layout-constrained & {
-		width: var(--wp--custom--width--wrapper);
+		// width: var(--wp--custom--width--wrapper);
+		// を指定してしまうを Windows でスクロールバーまでの幅を含めてた広さで検出してしまい、
+		// .alignfull のついていないHTML直下の要素の幅（100%）と差が発生する。
+		// これにより
+		// .alignfull > .is-layout-constrained > * と
+		// * > .is-layout-constrained > * で位置にズレが発生する
 		max-width: var(--wp--custom--width--wrapper) !important;
 		&.wp-block-image {
 			// Default block style overwrite

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Bug fix ] Fixed an issue where the layout would break on Windows devices depending on the nesting state of blocks.
 [ Bug fix ] Fix an issue where an alignwide element placed directly under post content with a specified content width is not centered properly.
 
 1.34.1


### PR DESCRIPTION
■ Before
![スクリーンショット 2025-07-10 19 05 39](https://github.com/user-attachments/assets/507e8038-e6e2-45fb-a2b9-3a1603042d9d)

■ After
![スクリーンショット 2025-07-10 19 05 58](https://github.com/user-attachments/assets/16e747d9-cca2-4e54-a2cf-3568cbe3c0c2)

```
<!-- wp:group {"style":{"border":{"width":"1px"}},"borderColor":"vivid-purple","layout":{"type":"constrained"}} -->
<div class="wp-block-group has-border-color has-vivid-purple-border-color" style="border-width:1px"><!-- wp:group {"style":{"border":{"left":{"color":"var:preset|color|vivid-red","width":"2px"},"right":{"color":"var:preset|color|vivid-red","width":"2px"}},"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group" style="border-right-color:var(--wp--preset--color--vivid-red);border-right-width:2px;border-left-color:var(--wp--preset--color--vivid-red);border-left-width:2px;padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:paragraph -->
<p>ヘッダー</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->

<!-- wp:group {"align":"full","style":{"border":{"width":"1px"}},"borderColor":"vivid-purple","layout":{"type":"default"}} -->
<div class="wp-block-group alignfull has-border-color has-vivid-purple-border-color" style="border-width:1px"><!-- wp:group {"align":"full","style":{"border":{"width":"1px"}},"borderColor":"vivid-green-cyan","layout":{"type":"constrained"}} -->
<div class="wp-block-group alignfull has-border-color has-vivid-green-cyan-border-color" style="border-width:1px"><!-- wp:group {"style":{"border":{"left":{"color":"var:preset|color|vivid-red","width":"2px"},"right":{"color":"var:preset|color|vivid-red","width":"2px"}},"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group" style="border-right-color:var(--wp--preset--color--vivid-red);border-right-width:2px;border-left-color:var(--wp--preset--color--vivid-red);border-left-width:2px;padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:paragraph -->
<p>ヘッダー</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->```

