### PR TITLE
alignfull／alignwide 内に置いた alignwide が 中央に配置されない問題を修正

### DIFF
--- a/assets/_scss/_block_width.scss
+++ b/assets/_scss/_block_width.scss
@@ -51,6 +51,14 @@
 		margin-left: calc((100% - var(--wp--custom--width--wrapper)) / 4) !important;
 		margin-right: calc((100% - var(--wp--custom--width--wrapper)) / 4) !important;
 	}
+	// alignwide や alignfull の中に入った alignwide は中央寄せ
+	@at-root {
+		.alignfull &,
+		.alignwide & {
+		  margin-left:  auto !important;
+		  margin-right: auto !important;
+		}
+	  }
 }
 
 /** サイドバーがある場合の幅調整 *****************************/

--- a/assets/_scss/_block_width.scss
+++ b/assets/_scss/_block_width.scss
@@ -1,6 +1,16 @@
 // WordPress標準の仕様の注意 :
+
+// .is-layout-constrained がついている要素の中の要素が、
+// 最大幅 コンテンツ幅 / 左右 auto になる
+// .is-layout-constrained がついていない or .is-layout-flow のクラスの中の要素は
+// 最大幅は 100% になる（親の幅に追従）
+
 // .is-layout-constrained のクラスの中の要素にコンテンツ幅が適用されるのであって、
 // .is-layout-constrained のクラス自体にコンテンツ幅が適用されるわけではない。
+
+// .alignfull や .alignwide に is-layout-constrained が付いていようが、
+// 直下の alignfull や alignwide の要素は中央揃えにする（マイナスオフセットしない）
+
 
 :is( .alignfull,.vk_outer-width-full ) {
 	// 直下でも constrained の中でも幅は同じ
@@ -39,26 +49,24 @@
 }
 
 .alignwide {
+
 	// 通常幅でインナーコンテナを持つブロック直下に幅広指定された場合
 	// （全幅や幅広のブロックのインナーコンテナの時点ではコンテンツ幅になっていないのでマイナスオフセットする必要がない）
-	:where(:not(:is(.alignfull, .alignwide))) > .is-layout-constrained[class*="__inner-container"] > &, 
-	// .is-layout-constrained > の中の要素（コンテンツ幅） > の中に幅広を配置された場合
+	:where(:not(:is(.alignfull, .alignwide))) > .is-layout-constrained[class*="__inner-container"] > &,
+
+	// .is-layout-constrained > の直下の要素（コンテンツ幅） > の直下に幅広を配置された場合
 	// ※ 2階層目がコンテンツ幅なので、最初の .is-layout-constrained の要素は alignll でも alignwide でも関係ない
 	.is-layout-constrained > :where(:not(:is(.alignfull, .alignwide))) > &,
-	// 通常幅の .is-layout-constrained の 中の要素（コンテンツ幅） の 中に幅広を配置された場合
-	// ※ 2階層目のコンテンツ幅の中にグループなどが入ってさらにその中になる事もあるので & の前に > は付けない
-	.is-layout-constrained:where(:not(:is(.alignfull, .alignwide))) > :where(:not(:is(.alignfull, .alignwide))) & {
+
+	// 通常幅の .is-layout-constrained > の直下の要素（コンテンツ幅） の中（3階層）の更に中（4階層）以降に幅広を配置された場合にマイナスオフセットする
+	// ※ 3階層は既にひとつ上の項目でやってる
+	// ※ コンテンツ幅の中にグループなどが入ってさらにその中（4階層以上）になる事もあるので、2階層と3階層の間には > は付けない
+	// ※ is( .alignnfull, .alignwide ) > .alignwide の場合はマイナスオフセットしない
+
+	.is-layout-constrained:where(:not(:is(.alignfull,.alignwide))) > :where(:not(:is(.alignfull,.alignwide))) :where(:not(:is(.alignfull, .alignwide))) > & {
 		margin-left: calc((100% - var(--wp--custom--width--wrapper)) / 4) !important;
 		margin-right: calc((100% - var(--wp--custom--width--wrapper)) / 4) !important;
 	}
-	// alignwide や alignfull の中に入った alignwide は中央寄せ
-	@at-root {
-		.alignfull &,
-		.alignwide & {
-		  margin-left:  auto !important;
-		  margin-right: auto !important;
-		}
-	  }
 }
 
 /** サイドバーがある場合の幅調整 *****************************/


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/x-t9/pull/376#issuecomment-3100633762 で、全幅内に配置した幅広ブロックが左に寄ってしまったので、テンプレートの作りの問題かと思い、マージしましたが、改めてcssを見ていて、全幅内に配置した幅広にも以下のcssがついてしまうのはおかしいな(テンプレートの作りの問題ではない)と思いまして、alignfull／alignwide 内に置いた alignwide は中央になるようにコードを追加しました。

**▼ 全幅内に配置した幅広ブロックにも以下のcssがついてしまう**

```
.alignwide {
         /* 既存コード */
	.is-layout-constrained:where(:not(:is(.alignfull, .alignwide))) > :where(:not(:is(.alignfull, .alignwide))) & {
		margin-left: calc((100% - var(--wp--custom--width--wrapper)) / 4) !important;
		margin-right: calc((100% - var(--wp--custom--width--wrapper)) / 4) !important;
	}
}	
```

1人は石川さんに確認していただきたいです。

## どういう変更をしたか？

* このプルリクで変更した事を記載してください

alignfull／alignwide 内に置いた alignwide は中央寄せになるようにcssを調整しました。

#### 変更前
<img width="1878" height="845" alt="スクリーンショット 2025-07-22 15 12 48" src="https://github.com/user-attachments/assets/0a361ce5-1bc4-4703-9268-cbc837088e25" />

#### 変更後
<img width="1903" height="616" alt="スクリーンショット 2025-07-22 15 04 29" src="https://github.com/user-attachments/assets/3b013980-8e58-4a57-b71d-1930dc82ef4f" />


実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [x] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？

scssの修正のみなのでスキップ

#### その他

- [ ] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

readme.txt はhttps://github.com/vektor-inc/x-t9/pull/376 のプルリクで書かれているので書いていません。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

①テンプレートから「シングル1カラム・テンプレート」を選択して、テンプレートのブロックの作りを添付画像のように、コンテンツ部分のメイン要素はページヘッダー部分とはグループを分けて作ります。

<img width="1431" height="722" alt="スクリーンショット 2025-07-22 15 37 24" src="https://github.com/user-attachments/assets/3d84b709-e693-46e5-9e30-a65c5da1d1fd" />

メイン要素のコードは以下になりますので、貼り付けてください。
【**▼メイン要素部分のコードは以下になります**】
```
<!-- wp:group {"tagName":"main","metadata":{"name":"main要素"},"layout":{"type":"constrained"}} -->
<main class="wp-block-group"><!-- wp:group {"layout":{"type":"default"}} -->
<div class="wp-block-group"><!-- wp:spacer {"height":"0px","className":"is-style-spacer-lg"} -->
<div style="height:0px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
<!-- /wp:spacer -->

<!-- wp:post-content {"layout":{"type":"constrained"}} /-->

<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
<!-- /wp:spacer -->

<!-- wp:group {"layout":{"type":"flex","allowOrientation":false,"justifyContent":"space-between"}} -->
<div class="wp-block-group"><!-- wp:post-navigation-link {"type":"previous"} /-->

<!-- wp:post-navigation-link /--></div>
<!-- /wp:group -->

<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
<!-- /wp:spacer -->

<!-- wp:separator {"className":"is-style-wide","backgroundColor":"border-normal"} -->
<hr class="wp-block-separator has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide"/>
<!-- /wp:separator -->

<!-- wp:comments {"className":"wp-block-comments-query-loop "} -->
<div class="wp-block-comments wp-block-comments-query-loop"><!-- wp:comments-title {"style":{"spacing":{"margin":{"top":"var:preset|spacing|70"}}}} /-->

<!-- wp:comment-template -->
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"width":"40px"} -->
<div class="wp-block-column" style="flex-basis:40px"><!-- wp:avatar {"size":40,"style":{"border":{"radius":"20px"}}} /--></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:comment-author-name {"fontSize":"small"} /-->

<!-- wp:group {"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}},"layout":{"type":"flex"}} -->
<div class="wp-block-group" style="margin-top:0px;margin-bottom:0px"><!-- wp:comment-date {"fontSize":"small"} /-->

<!-- wp:comment-edit-link {"fontSize":"small"} /--></div>
<!-- /wp:group -->

<!-- wp:comment-content /-->

<!-- wp:comment-reply-link {"fontSize":"small"} /--></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
<!-- /wp:comment-template -->

<!-- wp:comments-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
<!-- wp:comments-pagination-previous /-->

<!-- wp:comments-pagination-numbers /-->

<!-- wp:comments-pagination-next /-->
<!-- /wp:comments-pagination -->

<!-- wp:post-comments-form /--></div>
<!-- /wp:comments --></div>
<!-- /wp:group -->

<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
<!-- /wp:spacer -->

<!-- wp:columns {"style":{"spacing":{"margin":{"top":"0"},"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|50"}}}} -->
<div class="wp-block-columns" style="margin-top:0"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:heading {"level":4,"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|40","bottom":"var:preset|spacing|30","left":"var:preset|spacing|40"},"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"backgroundColor":"bg-secondary"} -->
<h4 class="wp-block-heading has-bg-secondary-background-color has-background" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--40)">
				Category</h4>
<!-- /wp:heading -->

<!-- wp:categories {"showHierarchy":true} /--></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:heading {"level":4,"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|40","bottom":"var:preset|spacing|30","left":"var:preset|spacing|40"},"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"backgroundColor":"bg-secondary"} -->
<h4 class="wp-block-heading has-bg-secondary-background-color has-background" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--40)">
				Archive</h4>
<!-- /wp:heading -->

<!-- wp:archives /--></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:spacer {"className":"is-style-spacer-xl"} -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
<!-- /wp:spacer --></main>
<!-- /wp:group -->
```

② 投稿を新規で作成して、テンプレートは「シングル1カラム」を選択 し、コードエディタに変更して、以下のコードを貼り付けます。

```
<!-- wp:group {"style":{"color":{"background":"#fbd7e0"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group has-background" style="background-color:#fbd7e0"><!-- wp:paragraph -->
<p>通常幅</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"align":"wide","style":{"color":{"background":"#d7effa"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group alignwide has-background" style="background-color:#d7effa"><!-- wp:paragraph -->
<p>幅広</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"align":"wide","style":{"color":{"background":"#d7effa"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group alignwide has-background" style="background-color:#d7effa"><!-- wp:paragraph -->
<p>幅広</p>
<!-- /wp:paragraph -->

<!-- wp:columns {"align":"wide","className":"vk_block-margin-sm\u002d\u002dmargin-bottom"} -->
<div class="wp-block-columns alignwide vk_block-margin-sm--margin-bottom"><!-- wp:column {"backgroundColor":"vivid-cyan-blue"} -->
<div class="wp-block-column has-vivid-cyan-blue-background-color has-background"><!-- wp:paragraph -->
<p>幅広の中に幅広</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column {"backgroundColor":"vivid-cyan-blue"} -->
<div class="wp-block-column has-vivid-cyan-blue-background-color has-background"><!-- wp:paragraph -->
<p>幅広の中に幅広</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:group {"align":"wide","backgroundColor":"vivid-cyan-blue","layout":{"type":"constrained"}} -->
<div class="wp-block-group alignwide has-vivid-cyan-blue-background-color has-background"><!-- wp:paragraph {"align":"left"} -->
<p class="has-text-align-left">幅広の中に幅広</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->

<!-- wp:group {"align":"full","style":{"color":{"background":"#faf5d7"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group alignfull has-background" style="background-color:#faf5d7"><!-- wp:paragraph -->
<p>全幅</p>
<!-- /wp:paragraph -->

<!-- wp:columns {"align":"wide","className":"vk_block-margin-sm\u002d\u002dmargin-bottom"} -->
<div class="wp-block-columns alignwide vk_block-margin-sm--margin-bottom"><!-- wp:column {"backgroundColor":"luminous-vivid-amber"} -->
<div class="wp-block-column has-luminous-vivid-amber-background-color has-background"><!-- wp:paragraph -->
<p>全幅の中に幅広</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column {"backgroundColor":"luminous-vivid-amber"} -->
<div class="wp-block-column has-luminous-vivid-amber-background-color has-background"><!-- wp:paragraph -->
<p>全幅の中に幅広</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:group {"align":"wide","backgroundColor":"luminous-vivid-amber","layout":{"type":"constrained"}} -->
<div class="wp-block-group alignwide has-luminous-vivid-amber-background-color has-background"><!-- wp:paragraph {"align":"left"} -->
<p class="has-text-align-left">全幅の中に幅広</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"align":"full","backgroundColor":"luminous-vivid-amber","layout":{"type":"constrained"}} -->
<div class="wp-block-group alignfull has-luminous-vivid-amber-background-color has-background"><!-- wp:paragraph {"align":"left"} -->
<p class="has-text-align-left">全幅の中に全幅</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```

③当ブランチでは、全幅や幅広に入れた幅広ブロックが中央に寄っていることを確認しました。
master ブランチでは左に寄っていることを確認しました。


## レビュワーの確認方法・確認する内容など

実装者と同じ手順で確認をお願いします。

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
