### PR TITLE
ナビゲーションのモーダルメニューをOPNEにした時に、フッターが上に表示されないように修正

### DIFF
--- a/assets/_scss/_footer.scss
+++ b/assets/_scss/_footer.scss
@@ -11,7 +11,7 @@ footer.wp-block-template-part {
 	z-index:9998;
 	// モーダルが固定ヘッダーの下にならないように、開いてる時は 9999 に指定
 	// to avoid modal element on fixed header, set 9999 when modal is open.
-	html.has-modal-open & {
+	html.has-modal-open:not(:has(.is-menu-open)) & {
 		z-index:9999;
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -12,6 +12,7 @@ The X-T9 is designed on the premise of full site editing function, and the user 
 GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
+[ Bug fix ] Prevented header menu from going under the footer.
 
 1.34.5
 [ Bug fix ] Fix default query in index /home / search ( If loading from a pattern automatically turns it into a custom query, then change it to writing directly to the template file instead. )


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/issues/assigned?issue=vektor-inc%7Cx-t9%7C386

## どういう変更をしたか？

* このプルリクで変更した事を記載してください
コアのナビゲーションのモーダルメニューをOPNEにした時に、フッターが上に表示されてしまうので、
モーダルメニューOPNE時のフッターのz-indexを一つ下げました。


実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

#### ソースコードについて

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？
パスします。

#### その他

- [ ] readme.txt に変更内容は書いたか？
- [ ] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [ ] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [ ] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど
テーマをx-t9にして、スマホの表示にする。
最下部までスクロールして、フッターを表示させる。
ハンバーガーメニューを開いて、フッターが上に来ないことを確認する。
固定ページにナビゲーションブロックを配置して、同様にフッターが上に来ないことを確認する。


## レビュワーの確認方法・確認する内容など
実装者と同じ

## レビュワーに回す前の確認事項

- [ ] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
