### PR TITLE
[ 仕様変更 ] ボタンの :active と :focus の時にもプライマリホバーと同じ色が適用されるように変更

### DIFF
--- a/assets/_scss/_button.scss
+++ b/assets/_scss/_button.scss
@@ -11,7 +11,7 @@
 	background-color: var(--wp--preset--color--primary);
 	text-decoration: none;
 	border-radius: var(--wp--custom--radius--button);
-	&:hover {
+	&:is(:hover, :active, :focus) {
 		--wp--preset--color--primary: var(--wp--preset--color--primary-hover);
 	}
 	:root & {

--- a/assets/_scss/plugin-override/_bootstrap-override.scss
+++ b/assets/_scss/plugin-override/_bootstrap-override.scss
@@ -1,7 +1,10 @@
+.btn,
 .btn-primary {
 	background-color: var(--wp--preset--color--primary);
 	border-color: var(--wp--preset--color--primary);
-	&:hover{
+	&:not(:disabled):not(.disabled):active,
+	&:is(:hover, :active, :focus){
+		border-color: var(--wp--preset--color--primary-hover);
 		background-color: var(--wp--preset--color--primary-hover);
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -12,6 +12,8 @@ The X-T9 is designed on the premise of full site editing function, and the user 
 GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
+
+[ Specification Change ] Changed buttons so that the same color as the primary hover is applied to :active and :focus states.
 [ Bug fix ] Prevented header menu from going under the footer.
 
 1.34.5


### PR DESCRIPTION
## 変更の目的・理由

ボタンの :active に指定がなかったために、 .btn クラスでは :active だと VK Blocks の Bootstrap の色などが適用されてしまっていた。

## 実装内容

X-T9 のプライマリホバーカラーが適用されるように指定

### 主な変更点
- [ ] 新機能追加
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [x] その他:

### 技術的な詳細
<!-- バグ修正の場合は、原因と対策を記載してください -->

## スクリーンショット
<!-- 変更前後のスクリーンショットや動画を添付してください -->

### Before（変更前）
<!-- スクリーンショットや動画を添付 -->

### After（変更後）
<!-- スクリーンショットや動画を添付 -->

## 実装者チェックリスト

### コード品質
- [x] 単一責任の原則に従っている（1つのPRで1つの変更のみ）
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] ワークフローファイルの変更を含んでいない（別PRで対応）
- [x] 変更ファイルの内容を目視で確認済み

### ドキュメント
- [x] `readme.txt`に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

### テスト
- [ ] 書けるテストは実装済み
- [ ] 既存のテストが通ることを確認
- [ ] 手動テストを実施済み

### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

### 動作確認時の注意事項
<!-- レビュー時に変更が反映されない場合の確認項目 -->

- [ ] 最新のコードをプルしている
- [ ] ビルドを実行している
- [ ] 正しいディレクトリで作業している
- [ ] `npm install`を実行している
- [ ] `composer install`を実行している
- [ ] キャッシュをクリアしている

### 追加の確認事項
<!-- 必要に応じて追加の確認項目を記載 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- スタイル
  - ボタンのプライマリホバー色を :hover に加え :active と :focus にも適用（無効状態は除外）。
  - 枠線色もホバー色に合わせ、背景色との一貫性を向上。

- ドキュメント
  - 変更履歴に、ボタンのアクティブ/フォーカスでもホバー色が適用される旨を追記。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->