### PR TITLE
[ 不具合修正 ] dist処理で画像などのバイナリファイルが壊れる不具合を修正

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,7 +64,12 @@ gulp.task('dist', function() {
 				"!./node_modules/**",
 				"!./docs/**"
 			],
-			{ base: './' }
+			{
+				base: './',
+				// Gulp 5 ではデフォルトの encoding が utf8 に変更されたため、
+				// バイナリファイル（画像など）が破損する。encoding: false を指定して回避する。
+				encoding: false,
+			}
 		)
 		.pipe( gulp.dest( 'dist/x-t9' ) );
 } );

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
-[ Other ] Improve dist process to prevent binary file corruption
+[ Bug Fix ] Fixed binary files (images, fonts, etc.) being corrupted during dist process
 
 = 1.37.4 =
 [ Specification Change / Bug fix ] Replaced clamp string values with fluid object format ( min/max ) for all font sizes except tiny in theme.json typography settings

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
-[ Bug Fix ] Fixed binary files (images, fonts, etc.) being corrupted during dist process
+[ Other ] Improve dist process to prevent binary file corruption
 
 = 1.37.4 =
 [ Specification Change / Bug fix ] Replaced clamp string values with fluid object format ( min/max ) for all font sizes except tiny in theme.json typography settings

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Bug Fix ] Fixed binary files (images, fonts, etc.) being corrupted during dist process
+
 = 1.37.4 =
 [ Specification Change / Bug fix ] Replaced clamp string values with fluid object format ( min/max ) for all font sizes except tiny in theme.json typography settings
 [ Specification Change ] Removed hardcoded clamp() override for --wp--preset--font-size--huge in _variables_wp660.scss that was a workaround for a WordPress bug


### PR DESCRIPTION
## 概要

Gulp 5 ではデフォルトの encoding が `utf8` に変更されたため、`gulp.src` でバイナリファイル（画像・フォントなど）をコピーすると破損します。`encoding: false` を指定して回避します。

## 変更内容

- `gulpfile.js` の `dist` タスクの `gulp.src` に `{ encoding: false }` を追加

## 参考

- vektor-inc/vk-block-patterns#255

## テスト

- `npx gulp dist` を実行して dist ディレクトリに出力された画像ファイルが壊れていないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ビルドプロセス中に画像やフォント等のバイナリファイルが破損していた問題を修正しました。配布用のビルドパイプラインで、これらのアセットが正しく処理されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->