### PR TITLE
[ 開発環境 ] npm run watch の監視対象に plugin-support/woocommerce/_scss を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"rimraf:css": "npx rimraf assets/_scss/*.css",
 		"build:css": "run-s sass postcss:all rimraf:css sass:woocommerce",
 		"build": "npx gulp convert-dynamic && npx gulp remove-theme-name && npm run build:script && npm run build:css",
-		"watch": "nodemon -e scss --watch assets/_scss -x \"npm run build:css && webpack --config webpack.js --watch && npm run dist\"",
+		"watch": "nodemon -e scss --watch assets/_scss --watch plugin-support/woocommerce/_scss -x \"npm run build:css && webpack --config webpack.js --watch && npm run dist\"",
 		"copy": "npx gulp dist",
 		"zip": "cd dist && zip -r x-t9.zip x-t9",
 		"dist": "run-s build copy zip",

--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 == Changelog ==
 
 [ Bug Fix ] Fixed binary files (images, fonts, etc.) being corrupted during dist process
+[ Dev Environment ] Added plugin-support/woocommerce/_scss to npm run watch targets so that woo.scss changes are detected
 
 = 1.37.4 =
 [ Specification Change / Bug fix ] Replaced clamp string values with fluid object format ( min/max ) for all font sizes except tiny in theme.json typography settings


### PR DESCRIPTION
## 概要

`npm run watch` の nodemon 監視対象が `assets/_scss` のみだったため、`plugin-support/woocommerce/_scss/woo.scss` を編集してもビルドがトリガーされず、`woo.css` が更新されない状態でした。

監視対象に `plugin-support/woocommerce/_scss` を追加し、woo.scss の変更でも自動的に `npm run build:css`（内部で `sass:woocommerce` を実行）が走るようにします。

## 変更内容

- `package.json` の `watch` スクリプトに `--watch plugin-support/woocommerce/_scss` を追加
- `readme.txt` の changelog に `[ Dev Environment ]` エントリを追記

## 確認手順

### 前提条件

- 依存パッケージがインストール済みであること（`npm install`）

### 手順

#### Before（修正前の挙動）

1. `master` ブランチで `npm run watch` を実行
2. 別ターミナルで `plugin-support/woocommerce/_scss/woo.scss` を編集して保存
   → ✗ 変更が検出されず、`plugin-support/woocommerce/css/woo.css` が更新されない

#### After（修正後）

1. このブランチで `npm run watch` を実行
2. 別ターミナルで `plugin-support/woocommerce/_scss/woo.scss` を編集して保存
   → ✓ 変更が検出され、`build:css` が走り `plugin-support/woocommerce/css/woo.css` が更新される
3. 続けて `assets/_scss` 配下のファイルを編集して保存
   → ✓ 従来どおり変更が検出され、ビルドが走る（デグレなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 開発環境の watch コマンドが拡張され、より広範な変更を検出できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->