### PR TITLE
[ 機能追加 ] WooCommerce 用テンプレート（商品一覧・商品詳細・カート・チェックアウト・商品検索結果）の追加

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -16,6 +16,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 [ Bug Fix ] Fixed binary files (images, fonts, etc.) being corrupted during dist process
 [ Specification Change ] Added styling for WooCommerce MyAccount, Cart, and Checkout pages
 [ Dev Environment ] Added plugin-support/woocommerce/_scss to npm run watch targets so that woo.scss changes are detected
+[ New Feature ] Added WooCommerce templates (archive-product, single-product, page-cart, page-checkout, product-search-results)
 
 = 1.37.4 =
 [ Specification Change / Bug fix ] Replaced clamp string values with fluid object format ( min/max ) for all font sizes except tiny in theme.json typography settings

--- a/templates/archive-product.html
+++ b/templates/archive-product.html
@@ -1,0 +1,96 @@
+<!-- wp:template-part {"slug":"header","theme":"x-t9"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
+<main class="wp-block-group"><!-- wp:cover {"overlayColor":"bg-secondary","isUserOverlayColor":true,"minHeight":50,"isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"0","right":"var:preset|spacing|50","bottom":"0","left":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:var(--wp--preset--spacing--50);padding-bottom:0;padding-left:var(--wp--preset--spacing--50);min-height:50px"><span aria-hidden="true" class="wp-block-cover__background has-bg-secondary-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:spacer {"className":"is-style-spacer-md"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
+<div class="wp-block-group"><!-- wp:query-title {"type":"archive","textAlign":"center","showPrefix":false,"style":{"spacing":{"margin":{"top":"0em","bottom":"0em","right":"0em","left":"0em"}}},"textColor":"text-normal"} /-->
+
+<!-- wp:term-description /--></div>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"className":"is-style-spacer-md"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull"><!-- wp:spacer {"className":"is-style-spacer-xxs"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xxs"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:woocommerce/breadcrumbs {"align":""} /-->
+
+<!-- wp:spacer {"className":"is-style-spacer-xxs"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xxs"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group -->
+
+<!-- wp:separator {"align":"full","className":"is-style-wide","backgroundColor":"border-normal"} -->
+<hr class="wp-block-separator alignfull has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide"/>
+<!-- /wp:separator -->
+
+<!-- wp:spacer {"className":"is-style-spacer-md"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:woocommerce/store-notices {"align":""} /-->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group"><!-- wp:woocommerce/product-results-count /-->
+
+<!-- wp:woocommerce/catalog-sorting /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"className":"is-style-spacer-sm"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-sm"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:woocommerce/product-collection {"queryId":39,"query":{"woocommerceAttributes":[],"woocommerceStockStatus":["instock","outofstock","onbackorder"],"taxQuery":[],"isProductCollectionBlock":true,"perPage":10,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"div","displayLayout":{"type":"flex","columns":3,"shrinkColumns":true},"dimensions":{"widthType":"fill","fixedWidth":""},"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"実際の商品は、閲覧ページによって異なります。"}} -->
+<div class="wp-block-woocommerce-product-collection"><!-- wp:woocommerce/product-template -->
+<!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} -->
+<!-- wp:woocommerce/product-sale-badge {"isDescendentOfQueryLoop":true,"align":"right"} /-->
+<!-- /wp:woocommerce/product-image -->
+
+<!-- wp:spacer {"className":"is-style-spacer-sm","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<div style="margin-top:0;margin-bottom:0;height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-sm"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:post-title {"textAlign":"center","isLink":true,"style":{"typography":{"lineHeight":"1.4","fontStyle":"normal","fontWeight":"400"}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
+
+<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
+<!-- /wp:woocommerce/product-template -->
+
+<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:query-pagination-previous /-->
+
+<!-- wp:query-pagination-numbers /-->
+
+<!-- wp:query-pagination-next /-->
+<!-- /wp:query-pagination -->
+
+<!-- wp:woocommerce/product-collection-no-results -->
+<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"center","flexWrap":"wrap"}} -->
+<div class="wp-block-group"><!-- wp:paragraph {"fontSize":"medium"} -->
+<p class="has-medium-font-size"><strong>No Posts</strong></p>
+<!-- /wp:paragraph -->
+</div>
+<!-- /wp:group -->
+<!-- /wp:woocommerce/product-collection-no-results --></div>
+<!-- /wp:woocommerce/product-collection -->
+
+<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+<!-- /wp:spacer --></main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","theme":"x-t9"} /-->

--- a/templates/page-cart.html
+++ b/templates/page-cart.html
@@ -1,0 +1,29 @@
+<!-- wp:template-part {"slug":"header","theme":"x-t9","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","align":"full","style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"inherit":true,"type":"constrained"}} -->
+<main class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0"><!-- wp:template-part {"slug":"page-header-page","theme":"x-t9","tagName":"div","align":"full"} /--></main>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:spacer {"className":"is-style-spacer-md"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
+<!-- wp:woocommerce/store-notices {"align":""} /-->
+
+<!-- wp:vk-blocks/spacer {"spaceSize":"small"} -->
+<div class="wp-block-vk-blocks-spacer vk_spacer vk_spacer-type-margin-top"><div class="vk_block-margin-sm--margin-top"></div></div>
+<!-- /wp:vk-blocks/spacer -->
+
+<!-- wp:post-content {"align":""} /-->
+<!-- /wp:woocommerce/page-content-wrapper -->
+
+<!-- wp:spacer {"className":"is-style-spacer-xl"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","theme":"x-t9","tagName":"footer"} /-->

--- a/templates/page-checkout.html
+++ b/templates/page-checkout.html
@@ -1,0 +1,25 @@
+<!-- wp:template-part {"slug":"header","theme":"x-t9","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","align":"full","style":{"spacing":{"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"inherit":true,"type":"constrained"}} -->
+<main class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0"><!-- wp:template-part {"slug":"page-header-page","theme":"x-t9","tagName":"div","align":"full"} /--></main>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
+<!-- wp:woocommerce/store-notices {"align":""} /-->
+
+<!-- wp:post-content {"align":""} /-->
+<!-- /wp:woocommerce/page-content-wrapper -->
+
+<!-- wp:spacer {"className":"is-style-spacer-xl"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xl"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","theme":"x-t9","tagName":"footer"} /-->

--- a/templates/product-search-results.html
+++ b/templates/product-search-results.html
@@ -1,0 +1,86 @@
+<!-- wp:template-part {"slug":"header","theme":"x-t9"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
+<main class="wp-block-group"><!-- wp:cover {"overlayColor":"bg-secondary","isUserOverlayColor":true,"minHeight":50,"isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"0","right":"var:preset|spacing|50","bottom":"0","left":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:var(--wp--preset--spacing--50);padding-bottom:0;padding-left:var(--wp--preset--spacing--50);min-height:50px"><span aria-hidden="true" class="wp-block-cover__background has-bg-secondary-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:spacer {"className":"is-style-spacer-md"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:query-title {"type":"search","showPrefix":false} /-->
+
+<!-- wp:spacer {"className":"is-style-spacer-md"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull"><!-- wp:spacer {"className":"is-style-spacer-xxs"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xxs"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:woocommerce/breadcrumbs {"align":""} /-->
+
+<!-- wp:spacer {"className":"is-style-spacer-xxs"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xxs"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group -->
+
+<!-- wp:separator {"align":"full","className":"is-style-wide","backgroundColor":"border-normal"} -->
+<hr class="wp-block-separator alignfull has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide"/>
+<!-- /wp:separator -->
+
+<!-- wp:woocommerce/store-notices {"align":""} /-->
+
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group"><!-- wp:woocommerce/product-results-count /-->
+
+<!-- wp:woocommerce/catalog-sorting /--></div>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"className":"is-style-spacer-sm"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-sm"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:woocommerce/product-collection {"queryId":3,"query":{"woocommerceAttributes":[],"woocommerceStockStatus":["instock","outofstock","onbackorder"],"taxQuery":[],"isProductCollectionBlock":true,"perPage":10,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":true},"tagName":"div","displayLayout":{"type":"flex","columns":3,"shrinkColumns":true},"dimensions":{"widthType":"fill","fixedWidth":""},"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":false,"previewMessage":"実際の商品は、閲覧ページによって異なります。"}} -->
+<div class="wp-block-woocommerce-product-collection"><!-- wp:woocommerce/product-template -->
+<!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} -->
+<!-- wp:woocommerce/product-sale-badge {"isDescendentOfQueryLoop":true,"align":"right"} /-->
+<!-- /wp:woocommerce/product-image -->
+
+<!-- wp:spacer {"className":"is-style-spacer-sm","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<div style="margin-top:0;margin-bottom:0;height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-sm"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:post-title {"textAlign":"center","isLink":true,"style":{"typography":{"lineHeight":"1.4","fontStyle":"normal","fontWeight":"400"}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
+
+<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
+<!-- /wp:woocommerce/product-template -->
+
+<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:query-pagination-previous /-->
+
+<!-- wp:query-pagination-numbers /-->
+
+<!-- wp:query-pagination-next /-->
+<!-- /wp:query-pagination -->
+
+<!-- wp:woocommerce/product-collection-no-results {"align":"wide"} -->
+<!-- wp:paragraph -->
+<p>
+	選択に一致する商品が見つかりませんでした。</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:search {"showLabel":false,"placeholder":"商品を検索...","buttonText":"検索","query":{"post_type":"product"}} /-->
+<!-- /wp:woocommerce/product-collection-no-results --></div>
+<!-- /wp:woocommerce/product-collection -->
+
+<!-- wp:spacer {"className":"is-style-spacer-lg"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
+<!-- /wp:spacer --></main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","theme":"x-t9"} /-->

--- a/templates/single-product.html
+++ b/templates/single-product.html
@@ -1,0 +1,88 @@
+<!-- wp:template-part {"slug":"header","theme":"x-t9"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
+<main class="wp-block-group"><!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull"><!-- wp:spacer {"className":"is-style-spacer-xxs"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xxs"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:woocommerce/breadcrumbs {"align":""} /-->
+
+<!-- wp:spacer {"className":"is-style-spacer-xxs"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xxs"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:separator {"align":"full","className":"is-style-wide","backgroundColor":"border-normal"} -->
+<hr class="wp-block-separator alignfull has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide"/>
+<!-- /wp:separator --></div>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"className":"is-style-spacer-md"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:woocommerce/store-notices {"align":""} /-->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"512px"} -->
+<div class="wp-block-column" style="flex-basis:512px"><!-- wp:woocommerce/product-image-gallery /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:post-title {"level":1,"fontSize":"xx-large","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
+
+<!-- wp:woocommerce/product-rating {"isDescendentOfSingleProductTemplate":true} /-->
+
+<!-- wp:woocommerce/product-price {"isDescendentOfSingleProductTemplate":true,"fontSize":"large"} /-->
+
+<!-- wp:post-excerpt {"excerptLength":100,"__woocommerceNamespace":"woocommerce/product-query/product-summary"} /-->
+
+<!-- wp:woocommerce/add-to-cart-form /-->
+
+<!-- wp:woocommerce/product-meta {"metadata":{"ignoredHookedBlocks":["core/post-terms"]}} -->
+<div class="wp-block-woocommerce-product-meta"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group"><!-- wp:woocommerce/product-sku /-->
+
+<!-- wp:post-terms {"term":"product_cat","prefix":"Category: "} /-->
+
+<!-- wp:post-terms {"term":"product_tag","prefix":"Tags: "} /-->
+
+<!-- wp:post-terms {"term":"product_brand","prefix":"ブランド: "} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:woocommerce/product-meta --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:woocommerce/product-details {"align":"","className":"is-style-minimal"} -->
+<div class="wp-block-woocommerce-product-details is-style-minimal"></div>
+<!-- /wp:woocommerce/product-details -->
+
+<!-- wp:woocommerce/product-collection {"queryId":1,"query":{"perPage":5,"pages":1,"offset":0,"postType":"product","order":"asc","orderBy":"title","search":"","exclude":[],"inherit":false,"taxQuery":[],"isProductCollectionBlock":true,"featured":false,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"filterable":false,"relatedBy":{"categories":true,"tags":true}},"tagName":"div","displayLayout":{"type":"flex","columns":5,"shrinkColumns":false},"dimensions":{"widthType":"fill"},"collection":"woocommerce/product-collection/related","hideControls":["inherit"],"queryContextIncludes":["collection"],"__privatePreviewState":{"isPreview":true,"previewMessage":"実際の商品は閲覧している商品によって異なります。"}} -->
+<div class="wp-block-woocommerce-product-collection"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"fontSize":"large"} -->
+<h2 class="wp-block-heading has-large-font-size" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30)">
+				関連商品			</h2>
+<!-- /wp:heading -->
+
+<!-- wp:woocommerce/product-template -->
+<!-- wp:woocommerce/product-image {"showSaleBadge":false,"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} -->
+<!-- wp:woocommerce/product-sale-badge {"isDescendentOfQueryLoop":true,"align":"right"} /-->
+<!-- /wp:woocommerce/product-image -->
+
+<!-- wp:spacer {"className":"is-style-spacer-sm","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<div style="margin-top:0;margin-bottom:0;height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-sm"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}},"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+
+<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small"} /-->
+
+<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"x-small"} /-->
+<!-- /wp:woocommerce/product-template --></div>
+<!-- /wp:woocommerce/product-collection -->
+
+<!-- wp:vk-blocks/spacer {"spaceSize":"large"} -->
+<div class="wp-block-vk-blocks-spacer vk_spacer vk_spacer-type-margin-top"><div class="vk_block-margin-lg--margin-top"></div></div>
+<!-- /wp:vk-blocks/spacer --></main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","theme":"x-t9"} /-->


### PR DESCRIPTION
## 概要

WooCommerce のショップ機能に対応するため、フルサイト編集 (FSE) 向けのブロックテンプレート HTML を追加します。これにより、ショップを利用するサイトでテーマ側があらかじめ用意したレイアウトでカート・チェックアウト等のページが表示されます。

追加するテンプレート:

| ファイル | 用途 |
|---|---|
| `templates/archive-product.html` | 商品アーカイブ（ショップトップ・商品カテゴリーなど） |
| `templates/single-product.html` | 商品詳細ページ |
| `templates/page-cart.html` | カートページ |
| `templates/page-checkout.html` | チェックアウトページ |
| `templates/product-search-results.html` | 商品検索結果ページ |

各テンプレートはテーマ既存の `header` / `footer` / `page-header-page` テンプレートパーツを利用し、コンテンツ部分に WooCommerce の各ブロック（`wp:woocommerce/page-content-wrapper`、`wp:woocommerce/store-notices` など）を配置しています。

## 変更内容

- `templates/archive-product.html` を新規追加
- `templates/single-product.html` を新規追加
- `templates/page-cart.html` を新規追加
- `templates/page-checkout.html` を新規追加
- `templates/product-search-results.html` を新規追加
- `readme.txt` の changelog に `[ New Feature ]` エントリを追記

## 確認手順

### 前提条件

- WooCommerce プラグインが有効化されていること
- テスト用のショップ・商品が登録済みで、商品カテゴリーが1つ以上設定されていること
- カート・チェックアウトの固定ページが WooCommerce 設定で割り当てられていること
- このブランチを有効化し、`npm run build` 済みであること

### 手順

#### 商品アーカイブ
1. フロントエンドで `/shop/` にアクセス
   → ✓ ヘッダー・ページヘッダー・商品一覧・フッターがテーマのレイアウトで表示される
2. 商品カテゴリーページ（例: `/product-category/<slug>/`）にアクセス
   → ✓ 同じレイアウトで商品一覧が表示される

#### 商品詳細
3. 任意の商品ページ（例: `/product/<slug>/`）にアクセス
   → ✓ 商品画像・タイトル・価格・カートへ追加ボタンなどがテーマレイアウトで表示される

#### カート・チェックアウト
4. 商品をカートに追加し `/cart/` を開く
   → ✓ ヘッダー・ページヘッダー・カート明細・フッターが表示され、レイアウト崩れがない
5. `/checkout/` を開く
   → ✓ チェックアウトフォームが同様のレイアウトで表示される

#### 商品検索結果
6. ショップ内検索などで商品検索を行い `/?s=...&post_type=product` 相当のページを開く
   → ✓ 商品検索結果がテーマレイアウトで表示される

#### サイトエディター
7. 管理画面 > 外観 > エディター > テンプレート 一覧を開く
   → ✓ 上記5テンプレートが選択肢として表示され、それぞれ編集可能

#### デグレ確認
8. WooCommerce 以外の通常の固定ページ・投稿・ホーム・404 を開く
   → ✓ 既存テンプレート（`page.html` / `single.html` / `front-page.html` / `404.html` 等）の表示に変化がない

## スクリーンショット

### Before
（テンプレート追加前のスクリーンショット — `/shop/` `/product/...` `/cart/` `/checkout/` `/?s=...&post_type=product`）

### After
（テンプレート追加後のスクリーンショット — 同じ URL）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * WooCommerceテンプレートを追加しました。商品アーカイブ、単一商品ページ、カート、チェックアウト、商品検索結果ページの表示に対応しました。これらのテンプレートにはヘッダー、フッター、ナビゲーション、商品レイアウト、ページネーション機能が含まれます。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/x-t9/pull/434)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->