### PR TITLE
[ 不具合修正 ] header タグがないページで発生するコンソールエラー（offsetHeight の TypeError）を修正

### DIFF
--- a/assets/_js/_master.js
+++ b/assets/_js/_master.js
@@ -15,9 +15,11 @@
     window.addEventListener('DOMContentLoaded', bodyClass, false)
 
     // ヘッダー要素がない場合の判別
+    // getElementsByTagName は要素ゼロでも空の HTMLCollection（truthy）を返すため、
+    // 要素数で判定する必要がある。
     const siteHeader = document.getElementsByTagName('header');
 
-    if( xt9Opt.header_scrool && siteHeader ){
+    if( xt9Opt.header_scrool && siteHeader.length > 0 ){
 
         // ヘッダーの元の高さを取得
 		// Get Header Height
@@ -28,19 +30,19 @@
 
         let header_scrool_func = ()=>{
 
-            let siteHeader = document.getElementsByTagName('header');
-            let siteHeaderNext = siteHeader.nextElementSibling;
+            // HTMLCollection ではなく実要素に対して nextElementSibling を呼ぶ必要がある。
+            let siteHeaderNext = siteHeader[0].nextElementSibling;
 
             if( ! body_class_lock && window.pageYOffset > siteHeaderContainerHeight ){
                 // ヘッダースクロール識別用のclass追加
                 document.body.classList.add('header-fixed-active')
-                if(xt9Opt.add_header_offset_margin){
-                    // コンテナ部分をfixedにするので、ガクンとならないように、ヘッダーの次の要素にヘッダーの高さ分余白を追加する 
+                if(xt9Opt.add_header_offset_margin && siteHeaderNext){
+                    // コンテナ部分をfixedにするので、ガクンとならないように、ヘッダーの次の要素にヘッダーの高さ分余白を追加する
                     siteHeaderNext.style.marginTop = siteHeaderContainerHeight + "px";
                 }
             } else {
                 document.body.classList.remove('header-fixed-active')
-                if(xt9Opt.add_header_offset_margin){
+                if(xt9Opt.add_header_offset_margin && siteHeaderNext){
                     siteHeaderNext.style.marginTop = null;
                 }
             }

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Bug Fix ] Fixed a console TypeError ( Cannot read properties of undefined (reading 'offsetHeight') ) on pages without a header tag, which prevented the scroll-related script from running
+
 = 1.38.0 =
 [ Bug Fix ] Fixed binary files (images, fonts, etc.) being corrupted during dist process
 [ Specification Change ] Added styling for WooCommerce MyAccount, Cart, and Checkout pages


### PR DESCRIPTION
## 概要

Closes #441

`header` タグがないテンプレート（フルサイト編集の特定テンプレなど）で、ブラウザコンソールに以下の TypeError が発生し、スクロール固定機能の初期化が止まる不具合を修正します。

```
main.js?ver=1.38.0:1 Uncaught TypeError: Cannot read properties of undefined (reading 'offsetHeight')
    at main.js?ver=1.38.0:1:275
    at main.js?ver=1.38.0:1:1197
```

## 原因

`assets/_js/_master.js` で以下の 2 点に問題がありました。

1. `document.getElementsByTagName('header')` は要素ゼロでも空の `HTMLCollection`（truthy）を返すため、`if( xt9Opt.header_scrool && siteHeader )` のガードが常に通り、`siteHeader[0]` が undefined のまま `.offsetHeight` を参照していた。
2. `header_scrool_func` 内で `HTMLCollection` に対して `.nextElementSibling` を呼んでおり、本来 `siteHeader[0].nextElementSibling` であるべき箇所がバグになっていた。

## 修正内容

- `assets/_js/_master.js`
  - ガード条件を `xt9Opt.header_scrool && siteHeader.length > 0` に変更し、`header` 要素がないページでは固定スクロール機能自体を発動しないようにした。
  - `header_scrool_func` 内の `siteHeader` 再宣言を削除し、外側のクロージャ変数 `siteHeader` を再利用。`siteHeader[0].nextElementSibling` で次要素を取得するように修正。
  - `siteHeaderNext` が `null`（header が DOM 末尾にあるなどの稀ケース）の場合のガードも追加。
- `readme.txt`
  - Changelog に `[ Bug Fix ]` エントリを追記。
- ビルド成果物 `assets/js/main.js` は webpack で再生成して動作確認済み（`assets/js/` は `.gitignore` 対象のためコミット対象外）。

## 確認手順

### 前提条件

- x-t9 テーマを有効化した WordPress（FSE で `header` ブロックを含まないテンプレートを用意できる状態）
- カスタマイザー等で **ヘッダースクロール固定** を有効にしておく（`xt9Opt.header_scrool = true` となる設定）

### 手順

#### Before（修正前の再現）

1. サイトエディター（外観 > エディター）でテンプレートを 1 つ開き、`header` ブロックを削除して保存する。
2. 該当テンプレートが適用されるページを公開側で開く。
3. ブラウザの DevTools コンソールを確認する。
   → ✗ `Uncaught TypeError: Cannot read properties of undefined (reading 'offsetHeight')` がコンソールに出力される。

#### After（修正後）

1. 上記と同じ「header ブロックを削除したテンプレート」が適用されるページを開き、コンソールを確認する。
   → ✓ TypeError が出ないこと。
2. ページを上下にスクロールする。
   → ✓ JS エラーが出ず、スクロール固定処理は何も起きない（header がないので当然動かないのが正しい挙動）。
3. 通常の `header` ブロックを含むテンプレートを開いて公開側を表示し、上下にスクロールする。
   → ✓ ヘッダーが画面上部に固定される（`header-fixed-active` クラスが付与される）。
   → ✓ `add_header_offset_margin` 有効時、ヘッダーの次の要素に高さ分の `margin-top` が付与され、スクロール時にレイアウトがガタつかない。
4. ヘッダー内のページ内リンクを含むボタンや、`a[href^='#']` を含むリンクをクリックする。
   → ✓ 一時的に `header-fixed-active` が外れて 2 秒後に復帰する従来の挙動が変わっていない。

## スクリーンショット

本修正は JS のロジック修正で UI 表示には影響しないため、スクリーンショットは省略。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ヘッダー要素が存在しないページでスクロール処理が正常に動作しないエラーを修正しました
  * ヘッダー固定時の余白設定ロジックを改善しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/x-t9/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/85