### PR TITLE
[ 仕様変更 ] エディタ Inspector でタイポグラフィコントロールをデフォルト表示

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -64,8 +64,10 @@ require get_template_directory() . '/inc/layout-helpers.php';
 require get_template_directory() . '/inc/block-patterns.php';
 // Add Block Styles.
 require get_template_directory() . '/inc/block-styles.php';
-// Typography control defaults for the editor inspector.
-require get_template_directory() . '/inc/typography-defaults.php';
+// Typography control defaults for the editor inspector (WordPress 6.6+).
+if ( version_compare( get_bloginfo( 'version' ), '6.6', '>=' ) ) {
+	require get_template_directory() . '/inc/typography-defaults.php';
+}
 // Load TGM.
 require get_template_directory() . '/inc/tgm-plugin-activation/tgm-config.php';
 

--- a/functions.php
+++ b/functions.php
@@ -64,6 +64,8 @@ require get_template_directory() . '/inc/layout-helpers.php';
 require get_template_directory() . '/inc/block-patterns.php';
 // Add Block Styles.
 require get_template_directory() . '/inc/block-styles.php';
+// Typography control defaults for the editor inspector.
+require get_template_directory() . '/inc/typography-defaults.php';
 // Load TGM.
 require get_template_directory() . '/inc/tgm-plugin-activation/tgm-config.php';
 

--- a/inc/typography-defaults.php
+++ b/inc/typography-defaults.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Typography control defaults for the block editor.
+ *
+ * ブロックエディタの Inspector で、フォントファミリー・フォントサイズ・
+ * 外観（太さ / スタイル）・行の高さ・文字間隔の各コントロールをデフォルト表示にする。
+ * 通常はパネル右の3点メニューから個別に表示する必要があるが、
+ * これらを毎回開かなくても使えるように block_type_metadata で
+ * supports.typography.__experimentalDefaultControls を補完する。
+ *
+ * @package vektor-inc/x-t9
+ */
+
+/**
+ * Show font family / size / appearance / line height / letter spacing by default in the editor inspector.
+ *
+ * タイポグラフィをサポートしているブロックすべてを対象に、
+ * ブロック自身が宣言しているサポート範囲内で
+ * __experimentalDefaultControls の対象項目を true にする。
+ * サポートしていない項目はそもそも表示されないため副作用は最小。
+ *
+ * @param array $metadata Block metadata as read from block.json.
+ * @return array Modified block metadata.
+ */
+function xt9_typography_default_controls( $metadata ) {
+	// タイポグラフィをサポートしないブロックは対象外。
+	// Skip blocks that don't declare typography support.
+	if ( empty( $metadata['supports']['typography'] ) || ! is_array( $metadata['supports']['typography'] ) ) {
+		return $metadata;
+	}
+
+	$typography = $metadata['supports']['typography'];
+
+	// ブロックが既にサポートしている項目だけをデフォルト表示対象にする。
+	// Only default-show the controls the block actually supports.
+	$defaults = array();
+
+	if ( ! empty( $typography['fontSize'] ) ) {
+		$defaults['fontSize'] = true;
+	}
+	if ( ! empty( $typography['lineHeight'] ) ) {
+		$defaults['lineHeight'] = true;
+	}
+	if ( ! empty( $typography['__experimentalFontFamily'] ) ) {
+		$defaults['fontFamily'] = true;
+	}
+	// 「外観」ドロップダウンは fontStyle と fontWeight の統合 UI で、
+	// Gutenberg 側のキーは fontAppearance（個別の fontStyle / fontWeight ではない）。
+	// The Appearance dropdown is a unified UI for fontStyle and fontWeight;
+	// Gutenberg checks `fontAppearance`, not the individual keys.
+	if ( ! empty( $typography['__experimentalFontStyle'] ) || ! empty( $typography['__experimentalFontWeight'] ) ) {
+		$defaults['fontAppearance'] = true;
+	}
+	if ( ! empty( $typography['__experimentalLetterSpacing'] ) ) {
+		$defaults['letterSpacing'] = true;
+	}
+
+	if ( empty( $defaults ) ) {
+		return $metadata;
+	}
+
+	// 既存の __experimentalDefaultControls とマージし、対象項目は上書きで表示にする。
+	// Merge with existing defaults; our keys win to enforce visibility.
+	$existing = ( isset( $typography['__experimentalDefaultControls'] ) && is_array( $typography['__experimentalDefaultControls'] ) )
+		? $typography['__experimentalDefaultControls']
+		: array();
+
+	$metadata['supports']['typography']['__experimentalDefaultControls'] = array_merge( $existing, $defaults );
+
+	return $metadata;
+}
+add_filter( 'block_type_metadata', 'xt9_typography_default_controls' );

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Specification Change ] Show font family, font size, appearance ( style / weight ), line height, and letter spacing typography controls by default in the editor inspector for blocks that support typography ( previously hidden behind the three-dot menu ); applied via supports.typography.__experimentalDefaultControls in the block_type_metadata filter
 [ New Feature ][ Group Block ] Enabled the core "Position: Fixed" option for the Group block ( supports.position.fixed via block_type_metadata filter + settings.position.fixed in theme.json, with frontend / editor CSS for is-position-fixed )
 [ Specification Change ][ Group Block ] Renamed the existing "Fixed header" block style label to "Header: Scrolled" ( internal name "scrolled-header-fixed" is kept for backward compatibility )
 [ Bug Fix ] Fixed a console TypeError ( Cannot read properties of undefined (reading 'offsetHeight') ) on pages without a header tag, which prevented the scroll-related script from running


### PR DESCRIPTION
## 概要

ブロックエディタの Inspector でタイポグラフィパネル内の各コントロール（フォントファミリー / フォントサイズ / 外観 / 行の高さ / 文字間隔）を、パネル右の3点メニューを開かなくてもデフォルトで表示するようにします。

`block_type_metadata` フィルタで `supports.typography.__experimentalDefaultControls` を補完することで、タイポグラフィをサポートする全ブロックに一律で適用します。ブロックが宣言しているサポート範囲内でのみコントロールを既定表示にするため、サポート外の項目が誤って表示される副作用はありません。

「外観」コントロールは Gutenberg 側のキー `fontAppearance`（fontStyle と fontWeight の統合 UI）を使用しています。

## 変更ファイル

- `inc/typography-defaults.php`（新規）
- `functions.php`（require 追加）
- `readme.txt`（changelog）

## 確認手順

### 前提条件
- WordPress 6.6 以上で、本テーマを有効化していること

### 手順

#### Before（変更前の挙動を見たい場合）
1. 投稿または固定ページの編集画面を開き、段落ブロックを追加する
2. 右サイドバーの「タイポグラフィ」パネルを確認する
   → ✗ デフォルトでは「サイズ」のみ表示され、フォントファミリー・外観・行の高さ・文字間隔はパネル右の3点メニューから開かないと表示されない

#### After（変更後）
1. 投稿または固定ページの編集画面を開き、段落ブロックを追加する
2. 右サイドバーの「タイポグラフィ」パネルを確認する
   → ✓ 「フォント」「サイズ」「外観」「行の高さ」「文字間隔」がデフォルトで表示される
3. 見出しブロック・リストブロックなど他のテキスト系ブロックでも同様に確認する
   → ✓ 各ブロックがサポートしているコントロールがデフォルトで表示される
4. グループブロックなどタイポグラフィをサポートしない／一部のみサポートするブロックを確認する
   → ✓ サポート外のコントロールは表示されない（副作用なし）
5. 各コントロールで値を変更して保存し、フロントで反映を確認する
   → ✓ 既存の動作と変わらず、変更が反映される（デグレなし）

## スクリーンショット

### Before
（変更前: タイポグラフィパネルにサイズのみ表示）

### After
（変更後: フォント・サイズ・外観・行の高さ・文字間隔がデフォルト表示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エディタのタイポグラフィ制御パネルがデフォルト表示されるようになりました
  * グループブロックで固定位置オプションがサポートされるようになりました

* **改善**
  * ブロックスタイルのラベル名を更新しました

* **バグ修正**
  * ヘッダーなしページでのスクロール機能の不具合を修正しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/x-t9/pull/444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->