### PR TITLE
[ 機能追加 ] Navigation Overlay テンプレートパートエリアと Overlay パターンを追加

### DIFF
--- a/assets/_scss/_navigation.scss
+++ b/assets/_scss/_navigation.scss
@@ -294,24 +294,32 @@ Overlay : allways ***********************
 	.wp-block-navigation__submenu-container{
 		border: none; // コアが border を付与してくるので打ち消す
 	}
-	.wp-block-navigation__submenu-container{
-		&.has-vk-color-primary-background-color{ // Adjusted to override WordPress core CSS. (for VK Pattern Library)
-			background-color: var(--wp--preset--color--primary);
-		}
-		&:where(:not(.has-background)) {
-			.wp-block-navigation-item {
+	// .is-horizontal の場合だけサブナビゲーションの背景に色をつける
+	// overlay を使うと .is-horizontal の中に overlay-content で .is-vertical のナビが入るという
+	// ふざけたケースが存在し、.is-vertical にも影響してしまうために、色をつける対象を限定している。
+	// ブロック直下（オーバーレイ指定なし）
+	& > .wp-block-navigation__container,
+	// レスポンシブコンテナ内（PC用）のみ
+	.wp-block-navigation__container.is-responsive {
+		.wp-block-navigation__submenu-container{
+			&.has-vk-color-primary-background-color{ // Adjusted to override WordPress core CSS. (for VK Pattern Library)
 				background-color: var(--wp--preset--color--primary);
 			}
-		}
-		.wp-block-navigation-item {
-			border-bottom: 1px solid var(--wp--preset--color--border-normal-darkbg);
-			&:hover {
-				background-color: var(--wp--preset--color--primary-hover);
+			&:where(:not(.has-background)) {
+				.wp-block-navigation-item {
+					background-color: var(--wp--preset--color--primary);
+				}
 			}
-		}
-		&:where(:not(.has-text-color)) {
 			.wp-block-navigation-item {
-				color: #fff; // No relation under Bright BG and Dark BG
+				border-bottom: 1px solid var(--wp--preset--color--border-normal-darkbg);
+				&:hover {
+					background-color: var(--wp--preset--color--primary-hover);
+				}
+			}
+			&:where(:not(.has-text-color)) {
+				.wp-block-navigation-item {
+					color: #fff; // No relation under Bright BG and Dark BG
+				}
 			}
 		}
 	}

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -69,6 +69,7 @@ function xt9_register_block_patterns() {
 		'query-image-left',
 		'query-subcontent',
 		'post-template-image-left', // used by loop-archive.html.
+		'navigation-overlay/overlay-default',
 	);
 
 	/**

--- a/inc/block-patterns.php
+++ b/inc/block-patterns.php
@@ -14,14 +14,15 @@
  */
 function xt9_register_block_patterns() {
 	$block_pattern_categories = array(
-		'featured'    => array( 'label' => _x( 'Featured', 'Pattern Category', 'x-t9' ) ),
-		'header'      => array( 'label' => _x( 'Headers', 'Pattern Category', 'x-t9' ) ),
-		'footer'      => array( 'label' => _x( 'Footers', 'Pattern Category', 'x-t9' ) ),
-		'sidebar'     => array( 'label' => _x( 'Sidebars', 'Pattern Category', 'x-t9' ) ),
-		'layout'      => array( 'label' => _x( 'Layout', 'Pattern Category', 'x-t9' ) ),
-		'query'       => array( 'label' => _x( 'Query', 'Pattern Category', 'x-t9' ) ),
-		'pages'       => array( 'label' => _x( 'Pages', 'Pattern Category', 'x-t9' ) ),
-		'pr-contents' => array( 'label' => _x( 'PR Contents', 'Pattern Category', 'x-t9' ) ),
+		'featured'           => array( 'label' => _x( 'Featured', 'Pattern Category', 'x-t9' ) ),
+		'header'             => array( 'label' => _x( 'Headers', 'Pattern Category', 'x-t9' ) ),
+		'footer'             => array( 'label' => _x( 'Footers', 'Pattern Category', 'x-t9' ) ),
+		'navigation-overlay' => array( 'label' => _x( 'Navigation Overlay', 'Pattern Category', 'x-t9' ) ),
+		'sidebar'            => array( 'label' => _x( 'Sidebars', 'Pattern Category', 'x-t9' ) ),
+		'layout'             => array( 'label' => _x( 'Layout', 'Pattern Category', 'x-t9' ) ),
+		'query'              => array( 'label' => _x( 'Query', 'Pattern Category', 'x-t9' ) ),
+		'pages'              => array( 'label' => _x( 'Pages', 'Pattern Category', 'x-t9' ) ),
+		'pr-contents'        => array( 'label' => _x( 'PR Contents', 'Pattern Category', 'x-t9' ) ),
 	);
 
 	/**
@@ -70,6 +71,7 @@ function xt9_register_block_patterns() {
 		'query-subcontent',
 		'post-template-image-left', // used by loop-archive.html.
 		'navigation-overlay/overlay-default',
+		'navigation-overlay/overlay-rich',
 	);
 
 	/**

--- a/inc/patterns/navigation-overlay/overlay-default.php
+++ b/inc/patterns/navigation-overlay/overlay-default.php
@@ -32,6 +32,10 @@ return array(
 <div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"primary","width":100} -->
 <div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-primary-background-color has-background wp-element-button">Contact</a></div>
 <!-- /wp:button --></div>
-<!-- /wp:buttons --></div>
+<!-- /wp:buttons -->
+
+<!-- wp:spacer {"className":"is-style-spacer-md"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+<!-- /wp:spacer --></div>
 <!-- /wp:group -->',
 );

--- a/inc/patterns/navigation-overlay/overlay-default.php
+++ b/inc/patterns/navigation-overlay/overlay-default.php
@@ -22,7 +22,7 @@ return array(
 <hr class="wp-block-separator has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 
-<!-- wp:navigation {"ref":32,"submenuVisibility":"click","overlayMenu":"never","className":"is-style-nav\u002d\u002dvertical-with-hr","layout":{"orientation":"vertical"}} /-->
+<!-- wp:navigation {"submenuVisibility":"click","overlayMenu":"never","className":"is-style-nav\u002d\u002dvertical-with-hr","layout":{"orientation":"vertical"}} /-->
 
 <!-- wp:spacer {"className":"is-style-spacer-md"} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>

--- a/inc/patterns/navigation-overlay/overlay-default.php
+++ b/inc/patterns/navigation-overlay/overlay-default.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Default Overlay
+ *
+ * @package vektor-inc/x-t9
+ */
+
+return array(
+	'title'      => __( 'Default Overlay', 'x-t9' ),
+	'categories' => array( 'navigation' ),
+	'blockTypes' => array( 'core/template-part/navigation-overlay' ),
+	'content'    => '<!-- wp:group {"metadata":{"patternName":"x-t9/navigation-overlay/overlay-default","name":"Default Overlay","categories":["navigation"]},"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"dimensions":{"minHeight":"100svh"}},"backgroundColor":"bg-primary","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-bg-primary-background-color has-background" style="min-height:100svh;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:navigation-overlay-close /-->
+
+<!-- wp:search {"showLabel":false,"width":100,"widthUnit":"%","buttonText":"","buttonUseIcon":true,"style":{"spacing":{"margin":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}}} /-->
+
+<!-- wp:spacer {"className":"is-style-spacer-md"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:separator {"className":"is-style-wide","backgroundColor":"border-normal"} -->
+<hr class="wp-block-separator has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide"/>
+<!-- /wp:separator -->
+
+<!-- wp:navigation {"ref":32,"submenuVisibility":"click","overlayMenu":"never","className":"is-style-nav\u002d\u002dvertical-with-hr","layout":{"orientation":"vertical"}} /-->
+
+<!-- wp:spacer {"className":"is-style-spacer-md"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"primary","width":100} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-primary-background-color has-background wp-element-button">Contact</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group -->',
+);

--- a/inc/patterns/navigation-overlay/overlay-default.php
+++ b/inc/patterns/navigation-overlay/overlay-default.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Default Overlay
+ * Overlay Default
  *
  * @package vektor-inc/x-t9
  */
 
 return array(
-	'title'      => __( 'Default Overlay', 'x-t9' ),
+	'title'      => __( 'Overlay Default', 'x-t9' ),
 	'categories' => array( 'navigation' ),
 	'blockTypes' => array( 'core/template-part/navigation-overlay' ),
-	'content'    => '<!-- wp:group {"metadata":{"patternName":"x-t9/navigation-overlay/overlay-default","name":"Default Overlay","categories":["navigation"]},"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"dimensions":{"minHeight":"100svh"}},"backgroundColor":"bg-primary","layout":{"type":"constrained"}} -->
+	'content'    => '<!-- wp:group {"metadata":{"patternName":"x-t9/navigation-overlay/overlay-default","name":"Overlay Default","categories":["navigation"]},"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"dimensions":{"minHeight":"100svh"}},"backgroundColor":"bg-primary","layout":{"type":"constrained"}} -->
 <div class="wp-block-group has-bg-primary-background-color has-background" style="min-height:100svh;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:navigation-overlay-close /-->
 
 <!-- wp:search {"showLabel":false,"width":100,"widthUnit":"%","buttonText":"","buttonUseIcon":true,"style":{"spacing":{"margin":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}}} /-->

--- a/inc/patterns/navigation-overlay/overlay-rich.php
+++ b/inc/patterns/navigation-overlay/overlay-rich.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Overlay Rich
+ *
+ * @package vektor-inc/x-t9
+ */
+
+return array(
+	'title'      => __( 'Overlay Rich', 'x-t9' ),
+	'categories' => array( 'navigation' ),
+	'blockTypes' => array( 'core/template-part/navigation-overlay' ),
+	'content'    => '<!-- wp:group {"metadata":{"patternName":"x-t9/navigation-overlay/overlay-rich","name":"Overlay Rich","categories":["navigation"]},"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"dimensions":{"minHeight":"100svh"}},"backgroundColor":"bg-primary","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-bg-primary-background-color has-background" style="min-height:100svh;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:navigation-overlay-close /-->
+
+<!-- wp:search {"showLabel":false,"width":100,"widthUnit":"%","buttonText":"","buttonUseIcon":true,"style":{"spacing":{"margin":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}}} /-->
+
+<!-- wp:spacer {"className":"is-style-spacer-md"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:separator {"className":"is-style-wide","backgroundColor":"border-normal"} -->
+<hr class="wp-block-separator has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide"/>
+<!-- /wp:separator -->
+
+<!-- wp:group {"layout":{"type":"grid","minimumColumnWidth":"180px"}} -->
+<div class="wp-block-group"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:image {"sizeSlug":"full","linkDestination":"none","style":{"border":{"width":"1px"}},"borderColor":"border-normal"} -->
+<figure class="wp-block-image size-full has-custom-border"><img src="http://wpnext-xt9.local/wp-content/themes/x-t9/inc/patterns/images/sample-image-gray.png" alt="" class="has-border-color has-border-normal-border-color" style="border-width:1px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"className":"is-style-spacer-xs"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xs"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading {"level":5,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"medium","anchor":"vk-blocks"} -->
+<h5 id="vk-blocks" class="wp-block-heading has-medium-font-size" style="font-style:normal;font-weight:400">Title Text</h5>
+<!-- /wp:heading --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:image {"sizeSlug":"full","linkDestination":"none","style":{"border":{"width":"1px"}},"borderColor":"border-normal"} -->
+<figure class="wp-block-image size-full has-custom-border"><img src="http://wpnext-xt9.local/wp-content/themes/x-t9/inc/patterns/images/sample-image-gray.png" alt="" class="has-border-color has-border-normal-border-color" style="border-width:1px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"className":"is-style-spacer-xs"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xs"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading {"level":5,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"medium","anchor":"vk-blocks"} -->
+<h5 id="vk-blocks" class="wp-block-heading has-medium-font-size" style="font-style:normal;font-weight:400">Title Text</h5>
+<!-- /wp:heading --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:image {"sizeSlug":"full","linkDestination":"none","style":{"border":{"width":"1px"}},"borderColor":"border-normal"} -->
+<figure class="wp-block-image size-full has-custom-border"><img src="http://wpnext-xt9.local/wp-content/themes/x-t9/inc/patterns/images/sample-image-gray.png" alt="" class="has-border-color has-border-normal-border-color" style="border-width:1px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"className":"is-style-spacer-xs"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xs"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading {"level":5,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"medium","anchor":"vk-blocks"} -->
+<h5 id="vk-blocks" class="wp-block-heading has-medium-font-size" style="font-style:normal;font-weight:400">Title Text</h5>
+<!-- /wp:heading --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:image {"sizeSlug":"full","linkDestination":"none","style":{"border":{"width":"1px"}},"borderColor":"border-normal"} -->
+<figure class="wp-block-image size-full has-custom-border"><img src="http://wpnext-xt9.local/wp-content/themes/x-t9/inc/patterns/images/sample-image-gray.png" alt="" class="has-border-color has-border-normal-border-color" style="border-width:1px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:spacer {"className":"is-style-spacer-xs"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xs"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:heading {"level":5,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"medium","anchor":"vk-blocks"} -->
+<h5 id="vk-blocks" class="wp-block-heading has-medium-font-size" style="font-style:normal;font-weight:400">Title Text</h5>
+<!-- /wp:heading --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"className":"is-style-spacer-md"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:navigation {"showSubmenuIcon":false,"submenuVisibility":"always","overlayMenu":"never","className":"is-style-nav\u002d\u002dvertical-with-hr","layout":{"orientation":"vertical"}} /-->
+
+<!-- wp:spacer {"height":"35px","className":"is-style-spacer-sm"} -->
+<div style="height:35px" aria-hidden="true" class="wp-block-spacer is-style-spacer-sm"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"className":"has-border-color has-border-normal-border-color has-background","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}}} -->
+<div class="wp-block-group has-border-color has-border-normal-border-color has-background" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:paragraph {"className":"vk_block-margin-0\u002d\u002dmargin-bottom","style":{"typography":{"letterSpacing":"1px","lineHeight":"1.2","textAlign":"center"}}} -->
+<p class="has-text-align-center vk_block-margin-0--margin-bottom" style="letter-spacing:1px;line-height:1.2">Contact us anytime.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer {"height":"35px","className":"is-style-spacer-xxs"} -->
+<div style="height:35px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xxs"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"5px"}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
+<div class="wp-block-group"><!-- wp:paragraph {"className":"vk_block-margin-0\u002d\u002dmargin-bottom vk_block-margin-0\u002d\u002dmargin-top","style":{"typography":{"fontSize":"2rem","lineHeight":"1"}}} -->
+<p class="vk_block-margin-0--margin-bottom vk_block-margin-0--margin-top" style="font-size:2rem;line-height:1"><strong>000-0000-0000</strong></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"height":"35px","className":"is-style-spacer-xxs"} -->
+<div style="height:35px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xxs"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.2","textAlign":"center"}},"fontSize":"small"} -->
+<p class="has-text-align-center has-small-font-size" style="line-height:1.2">Bussines time AM : 8:30 - PM 6:30</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:spacer {"height":"35px","className":"is-style-spacer-xs"} -->
+<div style="height:35px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xs"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"primary","width":100} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100"><a class="wp-block-button__link has-primary-background-color has-background wp-element-button">Contact</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"className":"is-style-spacer-sm"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-sm"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:cover {"url":"http://wpnext-xt9.local/wp-content/themes/x-t9/inc/patterns/images/sample-image-gray.png","dimRatio":60,"overlayColor":"bg-primary","isUserOverlayColor":true,"minHeight":50,"minHeightUnit":"px","isDark":false,"style":{"spacing":{"padding":{"top":"0em","right":"1.5em","bottom":"0em","left":"1.5em"}},"elements":{"link":{"color":{"text":"var:preset|color|text-normal"}}},"border":{"width":"1px"}},"textColor":"text-normal","borderColor":"border-normal"} -->
+<div class="wp-block-cover is-light has-border-color has-border-normal-border-color has-text-normal-color has-text-color has-link-color" style="border-width:1px;padding-top:0em;padding-right:1.5em;padding-bottom:0em;padding-left:1.5em;min-height:50px"><img class="wp-block-cover__image-background" alt="" src="http://wpnext-xt9.local/wp-content/themes/x-t9/inc/patterns/images/sample-image-gray.png" data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-bg-primary-background-color has-background-dim-60 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"style":{"spacing":{"padding":{"top":"1.5em","right":"1.5em","bottom":"1.5em","left":"1.5em"},"blockGap":"1px","margin":{"top":"1.5rem","bottom":"1.5rem"}},"color":{"background":"#ffffff4a"},"border":{"color":"#0000001a","width":"1px"}},"layout":{"type":"default"}} -->
+<div class="wp-block-group has-border-color has-background" style="border-color:#0000001a;border-width:1px;background-color:#ffffff4a;margin-top:1.5rem;margin-bottom:1.5rem;padding-top:1.5em;padding-right:1.5em;padding-bottom:1.5em;padding-left:1.5em"><!-- wp:heading {"className":"wp-block-heading is-style-vk-heading-plain","style":{"spacing":{"margin":{"top":"0","right":"0em","bottom":"var:preset|spacing|40","left":"0"}},"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"x-large"} -->
+<h2 class="wp-block-heading is-style-vk-heading-plain has-x-large-font-size" style="margin-top:0;margin-right:0em;margin-bottom:var(--wp--preset--spacing--40);margin-left:0;font-style:normal;font-weight:700">Banner Title</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50","left":"0"}}}} -->
+<p style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50);margin-left:0">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. </p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-outline","style":{"border":{"radius":"0px"},"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|50","bottom":"var:preset|spacing|30","left":"var:preset|spacing|50"}}},"fontSize":"small"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-small-font-size has-custom-font-size wp-element-button" style="border-radius:0px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--50)">Read more</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:spacer {"className":"is-style-spacer-md"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group -->',
+);

--- a/inc/patterns/navigation-overlay/overlay-rich.php
+++ b/inc/patterns/navigation-overlay/overlay-rich.php
@@ -25,7 +25,7 @@ return array(
 <!-- wp:group {"layout":{"type":"grid","minimumColumnWidth":"180px"}} -->
 <div class="wp-block-group"><!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:image {"sizeSlug":"full","linkDestination":"none","style":{"border":{"width":"1px"}},"borderColor":"border-normal"} -->
-<figure class="wp-block-image size-full has-custom-border"><img src="http://wpnext-xt9.local/wp-content/themes/x-t9/inc/patterns/images/sample-image-gray.png" alt="" class="has-border-color has-border-normal-border-color" style="border-width:1px"/></figure>
+<figure class="wp-block-image size-full has-custom-border"><img src="' . esc_url( get_template_directory_uri() ) . '/inc/patterns/images/sample-image-gray.png" alt="" class="has-border-color has-border-normal-border-color" style="border-width:1px"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:spacer {"className":"is-style-spacer-xs"} -->
@@ -39,7 +39,7 @@ return array(
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:image {"sizeSlug":"full","linkDestination":"none","style":{"border":{"width":"1px"}},"borderColor":"border-normal"} -->
-<figure class="wp-block-image size-full has-custom-border"><img src="http://wpnext-xt9.local/wp-content/themes/x-t9/inc/patterns/images/sample-image-gray.png" alt="" class="has-border-color has-border-normal-border-color" style="border-width:1px"/></figure>
+<figure class="wp-block-image size-full has-custom-border"><img src="' . esc_url( get_template_directory_uri() ) . '/inc/patterns/images/sample-image-gray.png" alt="" class="has-border-color has-border-normal-border-color" style="border-width:1px"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:spacer {"className":"is-style-spacer-xs"} -->
@@ -53,7 +53,7 @@ return array(
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:image {"sizeSlug":"full","linkDestination":"none","style":{"border":{"width":"1px"}},"borderColor":"border-normal"} -->
-<figure class="wp-block-image size-full has-custom-border"><img src="http://wpnext-xt9.local/wp-content/themes/x-t9/inc/patterns/images/sample-image-gray.png" alt="" class="has-border-color has-border-normal-border-color" style="border-width:1px"/></figure>
+<figure class="wp-block-image size-full has-custom-border"><img src="' . esc_url( get_template_directory_uri() ) . '/inc/patterns/images/sample-image-gray.png" alt="" class="has-border-color has-border-normal-border-color" style="border-width:1px"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:spacer {"className":"is-style-spacer-xs"} -->
@@ -67,7 +67,7 @@ return array(
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:image {"sizeSlug":"full","linkDestination":"none","style":{"border":{"width":"1px"}},"borderColor":"border-normal"} -->
-<figure class="wp-block-image size-full has-custom-border"><img src="http://wpnext-xt9.local/wp-content/themes/x-t9/inc/patterns/images/sample-image-gray.png" alt="" class="has-border-color has-border-normal-border-color" style="border-width:1px"/></figure>
+<figure class="wp-block-image size-full has-custom-border"><img src="' . esc_url( get_template_directory_uri() ) . '/inc/patterns/images/sample-image-gray.png" alt="" class="has-border-color has-border-normal-border-color" style="border-width:1px"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:spacer {"className":"is-style-spacer-xs"} -->
@@ -128,8 +128,8 @@ return array(
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-sm"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:cover {"url":"http://wpnext-xt9.local/wp-content/themes/x-t9/inc/patterns/images/sample-image-gray.png","dimRatio":60,"overlayColor":"bg-primary","isUserOverlayColor":true,"minHeight":50,"minHeightUnit":"px","isDark":false,"style":{"spacing":{"padding":{"top":"0em","right":"1.5em","bottom":"0em","left":"1.5em"}},"elements":{"link":{"color":{"text":"var:preset|color|text-normal"}}},"border":{"width":"1px"}},"textColor":"text-normal","borderColor":"border-normal"} -->
-<div class="wp-block-cover is-light has-border-color has-border-normal-border-color has-text-normal-color has-text-color has-link-color" style="border-width:1px;padding-top:0em;padding-right:1.5em;padding-bottom:0em;padding-left:1.5em;min-height:50px"><img class="wp-block-cover__image-background" alt="" src="http://wpnext-xt9.local/wp-content/themes/x-t9/inc/patterns/images/sample-image-gray.png" data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-bg-primary-background-color has-background-dim-60 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"style":{"spacing":{"padding":{"top":"1.5em","right":"1.5em","bottom":"1.5em","left":"1.5em"},"blockGap":"1px","margin":{"top":"1.5rem","bottom":"1.5rem"}},"color":{"background":"#ffffff4a"},"border":{"color":"#0000001a","width":"1px"}},"layout":{"type":"default"}} -->
+<!-- wp:cover {"url":"' . esc_url( get_template_directory_uri() ) . '/inc/patterns/images/sample-image-gray.png","dimRatio":60,"overlayColor":"bg-primary","isUserOverlayColor":true,"minHeight":50,"minHeightUnit":"px","isDark":false,"style":{"spacing":{"padding":{"top":"0em","right":"1.5em","bottom":"0em","left":"1.5em"}},"elements":{"link":{"color":{"text":"var:preset|color|text-normal"}}},"border":{"width":"1px"}},"textColor":"text-normal","borderColor":"border-normal"} -->
+<div class="wp-block-cover is-light has-border-color has-border-normal-border-color has-text-normal-color has-text-color has-link-color" style="border-width:1px;padding-top:0em;padding-right:1.5em;padding-bottom:0em;padding-left:1.5em;min-height:50px"><img class="wp-block-cover__image-background" alt="" src="' . esc_url( get_template_directory_uri() ) . '/inc/patterns/images/sample-image-gray.png" data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-bg-primary-background-color has-background-dim-60 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"style":{"spacing":{"padding":{"top":"1.5em","right":"1.5em","bottom":"1.5em","left":"1.5em"},"blockGap":"1px","margin":{"top":"1.5rem","bottom":"1.5rem"}},"color":{"background":"#ffffff4a"},"border":{"color":"#0000001a","width":"1px"}},"layout":{"type":"default"}} -->
 <div class="wp-block-group has-border-color has-background" style="border-color:#0000001a;border-width:1px;background-color:#ffffff4a;margin-top:1.5rem;margin-bottom:1.5rem;padding-top:1.5em;padding-right:1.5em;padding-bottom:1.5em;padding-left:1.5em"><!-- wp:heading {"className":"wp-block-heading is-style-vk-heading-plain","style":{"spacing":{"margin":{"top":"0","right":"0em","bottom":"var:preset|spacing|40","left":"0"}},"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"x-large"} -->
 <h2 class="wp-block-heading is-style-vk-heading-plain has-x-large-font-size" style="margin-top:0;margin-right:0em;margin-bottom:var(--wp--preset--spacing--40);margin-left:0;font-style:normal;font-weight:700">Banner Title</h2>
 <!-- /wp:heading -->

--- a/parts/navigation-overlay.html
+++ b/parts/navigation-overlay.html
@@ -1,0 +1,1 @@
+<!-- wp:pattern {"slug":"x-t9/navigation-overlay/overlay-default"} /-->

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ New Feature ] Added "Navigation Overlay" template part area and a default overlay pattern ( navigation-overlay/overlay-default ) for full-screen navigation
 [ Specification Change ] Show font family, font size, appearance ( style / weight ), line height, and letter spacing typography controls by default in the editor inspector for blocks that support typography ( previously hidden behind the three-dot menu ); applied via supports.typography.__experimentalDefaultControls in the block_type_metadata filter
 [ New Feature ][ Group Block ] Enabled the core "Position: Fixed" option for the Group block ( supports.position.fixed via block_type_metadata filter + settings.position.fixed in theme.json, with frontend / editor CSS for is-position-fixed )
 [ Specification Change ][ Group Block ] Renamed the existing "Fixed header" block style label to "Header: Scrolled" ( internal name "scrolled-header-fixed" is kept for backward compatibility )

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
-[ New Feature ] Added "Navigation Overlay" template part area and a default overlay pattern ( navigation-overlay/overlay-default ) for full-screen navigation
+[ New Feature ] Added "Navigation Overlay" template part area and a default overlay pattern for full-screen navigation
 [ Bug Fix ][ Navigation Block ] Fixed display issues on WordPress 7.0 ( updated selectors to handle the new submenu toggle button markup, cancelled the unwanted gap on always-open submenus, and adjusted padding for "Open on click" in the editor )
 [ Design Bug Fix ] Fixed an issue where buttons with a background color lost their padding ( excluded .wp-element-button from the .has-background padding reset )
 [ Specification Change ] Show font family, font size, appearance ( style / weight ), line height, and letter spacing typography controls by default in the editor inspector for blocks that support typography ( previously hidden behind the three-dot menu ); applied via supports.typography.__experimentalDefaultControls in the block_type_metadata filter

--- a/theme.json
+++ b/theme.json
@@ -519,6 +519,11 @@
 			"area": "header"
 		},
 		{
+			"name": "navigation-overlay",
+			"title": "Navigation Overlay",
+			"area": "navigation-overlay"
+		},
+		{
 			"name": "loop-archive",
 			"title": "Loop Archive ( Deprecated )",
 			"area": "uncategorized"


### PR DESCRIPTION
## 概要

ヘッダーのモバイルメニュー等で使用できる「Navigation Overlay」用のテンプレートパートエリアと、その初期表示となる Default Overlay パターンを追加します。

- `theme.json` の `templateParts` に `navigation-overlay` エリアを追加
- 新規テンプレートパート [parts/navigation-overlay.html](parts/navigation-overlay.html) を追加し、Default Overlay パターンを参照
- 新規パターン [inc/patterns/navigation-overlay/overlay-default.php](inc/patterns/navigation-overlay/overlay-default.php) を追加（検索フォーム・ナビゲーション・お問い合わせボタンを含む全画面オーバーレイ）
- [inc/block-patterns.php](inc/block-patterns.php) で上記パターンを登録

## 確認手順

### 前提条件

- このブランチを反映した X-T9 テーマを有効化
- WordPress 6.9 環境

### 手順

1. 管理画面 > 外観 > エディター（サイトエディター）を開く
2. 左メニューから「パターン」 > 「テンプレートパート」を選択
   → ✓ 「Navigation Overlay」エリアが表示される
3. 「Navigation Overlay」エリア内に `navigation-overlay` テンプレートパートが存在することを確認
   → ✓ 中身が Default Overlay パターン（検索フォーム・区切り線・ナビゲーション・Contact ボタン）として表示される
4. 任意のテンプレート（例: index）を編集し、テンプレートパートブロックを挿入する際にエリアとして「Navigation Overlay」が選択肢に出ることを確認
   → ✓ エリア選択肢に表示される
5. 既存のヘッダー・フッターのテンプレートパートが従来通り表示・編集できることを確認
   → ✓ デグレなし

## スクリーンショット

（テンプレートパートエリアの選択肢／Default Overlay パターンの表示を確認した状態を別途添付）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * フルスクリーンのナビゲーションオーバーレイを追加。デフォルトとリッチの2種類パターンを提供し、検索・閉じる・ボタン・グリッド表示などを含みます。
  * テンプレートパーツ領域「Navigation Overlay」をテーマに追加しました。
* **スタイル**
  * ナビゲーションのサブメニュー向けにスタイル適用範囲を限定し、見た目の一貫性を改善しました。
* **ドキュメント**
  * readme の Changelog を更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/x-t9/pull/445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->