### PR TITLE
[ デザイン不具合修正 ] ボタンに背景色を指定するとパディングが 0 になり潰れる不具合を修正

### DIFF
--- a/assets/_scss/style.scss
+++ b/assets/_scss/style.scss
@@ -46,7 +46,7 @@ body:where(:not([data-resizable-iframe-connected=""])),
 padding: 1.25em 2.375em;
 but actually not added case exist that reset padding to be aboid confusing.
 */
-.has-background,
+.has-background:where(:not(.wp-element-button)),
 :is(.wp-block-group):where(.has-background) {
 	padding: 0; // 編集画面の枠線ブロックなど弊害が出るのでこの指定は解除したい
 	// Don't use hidden. Because it bring to header navigation sub menu hidden.

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Bug Fix ] Fixed an issue where buttons with a background color lost their padding ( excluded .wp-element-button from the .has-background padding reset )
 [ Specification Change ] Show font family, font size, appearance ( style / weight ), line height, and letter spacing typography controls by default in the editor inspector for blocks that support typography ( previously hidden behind the three-dot menu ); applied via supports.typography.__experimentalDefaultControls in the block_type_metadata filter
 [ New Feature ][ Group Block ] Enabled the core "Position: Fixed" option for the Group block ( supports.position.fixed via block_type_metadata filter + settings.position.fixed in theme.json, with frontend / editor CSS for is-position-fixed )
 [ Specification Change ][ Group Block ] Renamed the existing "Fixed header" block style label to "Header: Scrolled" ( internal name "scrolled-header-fixed" is kept for backward compatibility )


### PR DESCRIPTION
## 概要

`.has-background` に対するパディング 0 リセットがコアのボタン要素（`.wp-element-button`）にも当たってしまい、背景色付きボタンの内側パディングが消えて潰れて見える不具合を修正します。

- [assets/_scss/style.scss](assets/_scss/style.scss) の `.has-background` セレクタを `.has-background:where(:not(.wp-element-button))` に変更し、ボタン要素を除外
- `:where()` でラップしているため詳細度は変化なし（既存の上書きルールに影響を与えない）

## 確認手順

### 前提条件

- このブランチを反映した X-T9 テーマを有効化
- 投稿または固定ページに「ボタン」ブロックを 1 つ配置できる状態

### 手順

#### Before（修正前の再現手順）

1. 投稿編集画面で「ボタン」ブロックを挿入
2. ボタンの「色」設定で **背景色** を任意の色（例: プライマリ）に指定
3. プレビューまたはフロントを開く
   → ✗ ボタンの内側のパディングが 0 になり、ラベル文字がボタンの端にくっついて潰れて見える

#### After（修正後）

1. 同じ手順で背景色付きのボタンを配置
2. プレビューまたはフロントを開く
   → ✓ ボタンの上下左右にコア標準のパディング（`1.25em 2.375em` 相当）が確保され、潰れていない
3. グループブロックに背景色を指定したケース、カバーブロックなど他の `.has-background` 要素を含むレイアウトを確認
   → ✓ 従来通り `padding: 0` のリセットが効いている（デグレなし）
4. 「ボタンブロック内に背景色付きの子要素」のような既存の組み合わせを確認
   → ✓ 既存の `.wp-block-button .has-background { overflow: inherit; }` 等と矛盾せず表示される

## スクリーンショット

### Before
（背景色付きボタンのパディングが潰れている状態のスクリーンショットを添付）

### After
（背景色付きボタンに正しいパディングが確保されている状態のスクリーンショットを添付）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 背景色付きボタンのパディング表示の問題を修正しました。ボタン要素のスタイルが正確に適用されるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/x-t9/pull/446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->