### PR TITLE
[ 不具合修正 ][ ナビゲーションブロック ] WordPress 7.0 のサブメニューのクリック展開でサブメニュー表示が崩れる不具合を修正

### DIFF
--- a/assets/_scss/_navigation.scss
+++ b/assets/_scss/_navigation.scss
@@ -285,6 +285,7 @@ Overlay : allways ***********************
 	.wp-block-navigation-item__content {
 		padding-left: var(--nav-top-item-padding-horizontal);
 	}
+
 	// エディタでコアが出力するCSSを上書きするため
 	.open-on-click .wp-block-navigation-item__content:not(.wp-block-navigation-submenu__toggle) {
 		padding-left: var(--nav-top-item-padding-horizontal);
@@ -307,10 +308,6 @@ Overlay : allways ***********************
 			&:hover {
 				background-color: var(--wp--preset--color--primary-hover);
 			}
-			*:where(:not(.is-style-nav--text-inline)) &.has-child>.wp-block-navigation-item__content {
-				// Additional Padding for submenu-icon
-				padding-right: calc(var(--submenu-icon-size) + var(--nav-top-item-padding-horizontal) + 0.5em);
-			}
 		}
 		&:where(:not(.has-text-color)) {
 			.wp-block-navigation-item {
@@ -323,6 +320,7 @@ Overlay : allways ***********************
  *  Vertical Navigation common styles
  */
  :where( .wp-block-navigation.is-vertical ) {
+
 	// エディタで open-on-click の時にコアが出力してくる padding:0 の上書き
 	// ※ナビは処理が複雑で eidtor.scss に分けると影響関係がわからなくなるのでこちらに記載
 	.wp-block-navigation-item.open-on-click {

--- a/assets/_scss/_navigation.scss
+++ b/assets/_scss/_navigation.scss
@@ -174,11 +174,13 @@ Overlay : allways ***********************
  *  Submenu Click
  */
  .wp-block-navigation .wp-block-navigation-item.open-on-click {
-	.wp-block-navigation-submenu__toggle {
-		padding-right: calc( var(--nav-top-item-padding-horizontal) + 1.2em );
+	// 詳細度を軽くするとエディタで WordPress コアの CSS に負けるので注意
+	button.wp-block-navigation-item__content:not(.wp-block-navigation-submenu__toggle),
+	.wp-block-navigation-item__content {
+		padding-right: calc( var(--nav-top-item-padding-horizontal) + 1.8em );
 	}
-	.wp-block-navigation-submenu__toggle+.wp-block-navigation__submenu-icon {
-		margin-left:-1.2em;
+	.wp-block-navigation-item__content+.wp-block-navigation__submenu-icon {
+		margin-left:-1.8em;
 	}
 }
 
@@ -249,10 +251,6 @@ Overlay : allways ***********************
 		}
 	}
 
-	// .wp-block-navigation-item .wp-block-site-logo a {
-	// 	padding: 1em var(--wp--custom--spacing--menu-indent);
-	// }
-
 	.wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__responsive-container-content {
 		.wp-block-navigation-item {
 			.wp-block-navigation-item__content {
@@ -287,6 +285,10 @@ Overlay : allways ***********************
 	.wp-block-navigation-item__content {
 		padding-left: var(--nav-top-item-padding-horizontal);
 	}
+	// エディタでコアが出力するCSSを上書きするため
+	.open-on-click .wp-block-navigation-item__content:not(.wp-block-navigation-submenu__toggle) {
+		padding-left: var(--nav-top-item-padding-horizontal);
+	}
 	&:not(.has-background) .wp-block-navigation__submenu-container,
 	.wp-block-navigation__submenu-container{
 		border: none; // コアが border を付与してくるので打ち消す
@@ -305,7 +307,7 @@ Overlay : allways ***********************
 			&:hover {
 				background-color: var(--wp--preset--color--primary-hover);
 			}
-			*:where(:not(.is-style-nav--text-inline)) &.has-child>a {
+			*:where(:not(.is-style-nav--text-inline)) &.has-child>.wp-block-navigation-item__content {
 				// Additional Padding for submenu-icon
 				padding-right: calc(var(--submenu-icon-size) + var(--nav-top-item-padding-horizontal) + 0.5em);
 			}
@@ -321,5 +323,13 @@ Overlay : allways ***********************
  *  Vertical Navigation common styles
  */
  :where( .wp-block-navigation.is-vertical ) {
-	// nothing now
+	// エディタで open-on-click の時にコアが出力してくる padding:0 の上書き
+	// ※ナビは処理が複雑で eidtor.scss に分けると影響関係がわからなくなるのでこちらに記載
+	.wp-block-navigation-item.open-on-click {
+		button.wp-block-navigation-item__content:not(.wp-block-navigation-submenu__toggle) {
+			padding-top: 0.5em;
+			padding-bottom: 0.5em;
+		}
+	}
 }
+

--- a/assets/_scss/_navigation.scss
+++ b/assets/_scss/_navigation.scss
@@ -320,7 +320,6 @@ Overlay : allways ***********************
  *  Vertical Navigation common styles
  */
  :where( .wp-block-navigation.is-vertical ) {
-
 	// エディタで open-on-click の時にコアが出力してくる padding:0 の上書き
 	// ※ナビは処理が複雑で eidtor.scss に分けると影響関係がわからなくなるのでこちらに記載
 	.wp-block-navigation-item.open-on-click {

--- a/assets/_scss/_navigation.scss
+++ b/assets/_scss/_navigation.scss
@@ -3,7 +3,6 @@
  */
 
  /*
-
 // HTML hierarchy
 .wp-block-navigation {
 	.wp-block-navigation__responsive-container {
@@ -20,6 +19,21 @@
 		}
 	}
 }
+
+Direction : horizontal ***********************
+.wp-block-navigation.is-horizontal
+
+Direction : vertical ***********************
+.wp-block-navigation.is-vertical
+
+Submenu Display : hover ***********************
+.wp-block-navigation-submenu
+
+Submenu Display : click ***********************
+.wp-block-navigation-submenu.open-on-click
+
+Submenu Display : always ***********************
+.wp-block-navigation-submenu.open-always
 
 Overlay : off ***********************
 .wp-block-navigation
@@ -139,8 +153,37 @@ Overlay : allways ***********************
 	}
  }
 
+ /****************************************************** 
+ *  Submenu always
+ */
+// 7.0 のサブメニュー常時表示で gap が付与されてしまうので打ち消し
+// セレクタを弱くしてしまうとコアに負けるので注意
+.wp-block-navigation .wp-block-navigation-submenu.open-always.has-child {
+	gap:0;
+	.wp-block-navigation__submenu-container {
+		padding-left:0;
+		padding-right:0;
+		gap:0;
+		.wp-block-navigation-submenu {
+			gap:0;
+		}
+	}
+}
+
 /****************************************************** 
- * Sub Navigation Styles
+ *  Submenu Click
+ */
+ .wp-block-navigation .wp-block-navigation-item.open-on-click {
+	.wp-block-navigation-submenu__toggle {
+		padding-right: calc( var(--nav-top-item-padding-horizontal) + 1.2em );
+	}
+	.wp-block-navigation-submenu__toggle+.wp-block-navigation__submenu-icon {
+		margin-left:-1.2em;
+	}
+}
+
+/****************************************************** 
+ * Submenu Styles
  */
 .wp-block-navigation{
 	// Override the padding specified by WordPress 6.9
@@ -240,7 +283,7 @@ Overlay : allways ***********************
 /****************************************************** 
  *  Horizontal Navigation common styles
  */
- .wp-block-navigation:where(:not(.is-vertical,.is-style-nav--vertical-with-hr-and-no-fold,.is-style-nav--vertical-with-hr )) {
+ .wp-block-navigation:is(.is-horizontal) {
 	.wp-block-navigation-item__content {
 		padding-left: var(--nav-top-item-padding-horizontal);
 	}

--- a/assets/_scss/_navigation_additional-class.scss
+++ b/assets/_scss/_navigation_additional-class.scss
@@ -56,12 +56,12 @@
 	// Overlay : off（ It is now positioned directly below .wp-block-navigation. ）
 	& > :where( .wp-block-navigation__container, .wp-block-page-list ) {
 			&>.wp-block-navigation-item {
-				&>a {
+				&>:where(:is( a, .wp-block-navigation-submenu__toggle )) {
 					padding-top: 1em;
 					padding-bottom: 1em;
 				}
 
-				&>a::after {
+				&>:where(:is( a, .wp-block-navigation-submenu__toggle ))::after {
 					transition: all 0.2s ease-out;
 					width: 0%;
 					content: '';
@@ -73,7 +73,11 @@
 				}
 				// .current-menu-ancestor は WP6.8になったら a に付与されるので追加
 				// :isの中の .current-menu-ancestor は WP6.8が安定したら削除
-				&> :is(a:hover, .current-menu-item > a, .current-menu-ancestor > a, .current-menu-ancestor) {
+				&> :is(
+					:where(:is( a, .wp-block-navigation-submenu__toggle )):hover, 
+					.current-menu-item > :where(:is( a, .wp-block-navigation-submenu__toggle )), 
+					.current-menu-ancestor > :where(:is( a, .wp-block-navigation-submenu__toggle )), 
+					.current-menu-ancestor) {
 					&::after {
 						width: 100%;
 					}
@@ -106,26 +110,16 @@
 			&:last-child {
 				border-right: 1px solid var(--nav--text-inline--border);
 			}
-			.wp-block-navigation__submenu-icon {
-				display: none;
-			}
 		}
-		.wp-block-navigation-item {
-			&:last-child {
-				border-right: 1px solid var(--nav--text-inline--border);
-			}
-
-			a:hover {
+		& >.wp-block-navigation-item {
+			& > .wp-block-navigation-item__content:hover {
 				text-decoration: underline;
+				text-underline-offset: 0.25em;
 			}
 		}
 		:where( .wp-block-navigation-item__content ) {
 			padding-top: 0;
 			padding-bottom: 0;
-		}
-		// Dusable sub menu
-		.has-child .wp-block-navigation__submenu-container {
-			display: none;
 		}
 	}
 
@@ -168,7 +162,7 @@
 		.wp-block-navigation-item__content {
 			grid-row: 1 / 2;
 			grid-column: 1 / 3;
-			padding: 0.8em;
+			padding: var(--wp--custom--spacing--menu-indent);
 		}
 		.wp-block-navigation__submenu-icon  {
 			grid-row: 1 / 2;
@@ -214,50 +208,37 @@
 	.wp-block-navigation-item__content:hover {
 		background-color: rgba(0,0,0,0.05);
 	}
-
-	// 7.0 のサブメニュー常時表示で gap が付与されてしまうので打ち消し
-	.has-child.open-always {
-		gap:0;
-		.wp-block-navigation__submenu-container {
-			padding-left:0;
-			padding-right:0;
-			gap:0;
-			.wp-block-navigation-submenu {
-				gap:0;
-			}
-		}
-	}
 }
 
 /****************************************************** 
- * Vertical with hr submenu
+ * Vertical with hr submenu animation
  */
 .wp-block-navigation[class*='nav--vertical-with-hr']:where(:not([class*='nav--vertical-with-hr-and-no-fold'])) {
 	.has-child .wp-block-navigation__submenu-container {
-		display: grid;
-		transition: all 1s ease-out;
-		overflow: hidden;
-		height:unset;
-		max-height:0svh;
+	// 	display: grid;
+		// 	overflow: hidden;
+		// transition: all 1s ease-out;
+		// height:unset;
+		// max-height:0svh;
 	}
 	.has-child:hover > .wp-block-navigation__submenu-container {
-		max-height:100svh;
-		overflow-y: scroll;
+		// max-height:100svh;
+	// 	overflow-y: scroll;
 	}
 	// オーバーレイでは折りたたまないので max-height を上書き
-	.wp-block-navigation__responsive-container.has-modal-open .wp-block-navigation__submenu-container {
-		max-height:100%;
-	}
+	// .wp-block-navigation__responsive-container.has-modal-open .wp-block-navigation__submenu-container {
+	// 	max-height:100%;
+	// }
 }
 
 // 編集画面でメニュー項目を選択すると WordPress 標準がまた別のCSSを吐き出したりして崩れるので、.is-selected が付いたらサブ階層は強制的に表示する
 .wp-block-navigation[class*='nav--vertical-with-hr']:where(:not([class*='nav--vertical-with-hr-and-no-fold'])):has(.is-selected) {
 	.has-child .wp-block-navigation__submenu-container {
-		display: grid;
-		height: auto;
-		opacity: 1;
-		visibility: visible;
-		max-height: unset;
+		// display: grid;
+		// height: auto;
+		// opacity: 1;
+		// visibility: visible;
+		// max-height: unset;
 	}
 }
 

--- a/assets/_scss/_navigation_additional-class.scss
+++ b/assets/_scss/_navigation_additional-class.scss
@@ -214,6 +214,19 @@
 	.wp-block-navigation-item__content:hover {
 		background-color: rgba(0,0,0,0.05);
 	}
+
+	// 7.0 のサブメニュー常時表示で gap が付与されてしまうので打ち消し
+	.has-child.open-always {
+		gap:0;
+		.wp-block-navigation__submenu-container {
+			padding-left:0;
+			padding-right:0;
+			gap:0;
+			.wp-block-navigation-submenu {
+				gap:0;
+			}
+		}
+	}
 }
 
 /****************************************************** 

--- a/assets/_scss/_navigation_additional-class.scss
+++ b/assets/_scss/_navigation_additional-class.scss
@@ -164,6 +164,11 @@
 			grid-column: 1 / 3;
 			padding: var(--wp--custom--spacing--menu-indent);
 		}
+		// エディタで On click の時にコアが出力してくる padding:0 の上書き
+		// ※ナビは処理が複雑で eidtor.scss に分けると影響関係がわからなくなるのでこちらに記載
+		&.open-on-click button.wp-block-navigation-item__content{
+			padding: var(--wp--custom--spacing--menu-indent);
+		}
 		.wp-block-navigation__submenu-icon  {
 			grid-row: 1 / 2;
 			grid-column: 2 / 3;
@@ -229,17 +234,6 @@
 	// .wp-block-navigation__responsive-container.has-modal-open .wp-block-navigation__submenu-container {
 	// 	max-height:100%;
 	// }
-}
-
-// 編集画面でメニュー項目を選択すると WordPress 標準がまた別のCSSを吐き出したりして崩れるので、.is-selected が付いたらサブ階層は強制的に表示する
-.wp-block-navigation[class*='nav--vertical-with-hr']:where(:not([class*='nav--vertical-with-hr-and-no-fold'])):has(.is-selected) {
-	.has-child .wp-block-navigation__submenu-container {
-		// display: grid;
-		// height: auto;
-		// opacity: 1;
-		// visibility: visible;
-		// max-height: unset;
-	}
 }
 
 /****************************************************** 

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Bug Fix ][ Navigation Block ] Fixed display issues on WordPress 7.0 ( updated selectors to handle the new submenu toggle button markup, cancelled the unwanted gap on always-open submenus, and adjusted padding for "Open on click" in the editor )
 [ Design Bug Fix ] Fixed an issue where buttons with a background color lost their padding ( excluded .wp-element-button from the .has-background padding reset )
 [ Specification Change ] Show font family, font size, appearance ( style / weight ), line height, and letter spacing typography controls by default in the editor inspector for blocks that support typography ( previously hidden behind the three-dot menu ); applied via supports.typography.__experimentalDefaultControls in the block_type_metadata filter
 [ New Feature ][ Group Block ] Enabled the core "Position: Fixed" option for the Group block ( supports.position.fixed via block_type_metadata filter + settings.position.fixed in theme.json, with frontend / editor CSS for is-position-fixed )


### PR DESCRIPTION
## 概要

WordPress 7.0 でナビゲーションブロックのマークアップが変わり（サブメニュー切り替え要素が `<a>` から `<button class="wp-block-navigation-submenu__toggle">` に変更）、既存の CSS セレクタに合致せずに表示崩れが発生していました。本 PR では以下を修正します。

- サブメニュートグル `button.wp-block-navigation-submenu__toggle` も `<a>` と同じ装飾対象になるようセレクタを調整
- 常時表示サブメニュー（`.open-always`）にコアが付与する `gap` を打ち消し
- 「クリックで開く」（`.open-on-click`）モードでエディタ側にコアが出力する `padding:0` の打ち消しと、矢印アイコン用の右パディング・水平方向の余白を調整
- 縦並びの折りたたみアニメーション処理（`nav--vertical-with-hr`）の挙動を見直し、影響範囲を整理

## 確認手順

### 前提条件
- WordPress 7.0 以上
- X-T9 テーマを有効化
- ナビゲーションブロックを含むテンプレート（ヘッダーなど）が存在すること

### 手順

#### Before（修正前の再現手順）

1. WordPress 7.0 でサイトエディター > テンプレートパーツ > Header を開く
2. ナビゲーションブロックを選択し、サブメニューを持つメニュー項目を追加する
3. インスペクター > サブメニュー > 「クリックで開く」を選択する
4. エディター上でメニュー項目の表示を確認する
   → ✗ パディングが `0` になり潰れて表示される / 矢印アイコンが想定位置に出ない
5. サブメニューの表示設定を「常時表示」に変更する
   → ✗ サブメニュー項目間に意図しない `gap` が入って隙間が空く
6. ナビゲーション内の各メニュー項目（特にサブメニューを持つ項目）にホバーする
   → ✗ 下線アニメーション・現在ページ表示などのスタイルが `<a>` にしか効かず、サブメニュートグルボタンには適用されない

#### After（修正後の確認手順）

1. 同じ手順でエディターを開き、「クリックで開く」を選択する
   → ✓ メニュー項目に適切な左右パディングが付き、矢印アイコンが正しい位置に表示される
2. サブメニュー表示を「常時表示」にする
   → ✓ サブメニュー項目同士に `gap` 由来の隙間が入らない
3. ホバー・現在ページの装飾を確認する
   → ✓ `<a>` のメニュー項目・`button.wp-block-navigation-submenu__toggle` のメニュー項目どちらでも下線アニメーション／現在ページ表示が同じように適用される
4. ナビゲーションのスタイル（横並び・縦並び・テキストインライン等）を切り替える
   → ✓ 既存スタイルがデグレしていない
5. 公開側でも同じ操作を行い、ブラウザでメニュー表示を確認する
   → ✓ エディターと同じ見た目で表示される

### デグレ確認

- WordPress 6.9 以下でも従来通り表示が崩れないこと（既存セレクタは `:is()` / `:where()` でまとめており、`<a>` のスタイルは維持される想定）

## スクリーンショット

CSS の表示変更を含むため、Before / After のスクリーンショットはレビュー時に追加します（PC / モバイルの主要ブレークポイントを想定）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ナビゲーションの表示とスペース調整を改善しました（サブメニューの常時表示・クリック時表示・アイコン周りの余白など）。
  * 横並び/縦並びでのパディングとトグル表示の挙動を安定化しました。
  * 一部のサブメニュー展開アニメーションや折りたたみ挙動を整理しました。

* **Documentation**
  * リリースノートにナビゲーション関連の変更点を追記しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/x-t9/pull/447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->