### PR TITLE
[ デザイン不具合修正 ][ ナビゲーションブロック ] オーバーレイナビゲーション項目が x-small フォントサイズで表示される不具合を修正

### DIFF
--- a/assets/_scss/_navigation.scss
+++ b/assets/_scss/_navigation.scss
@@ -208,7 +208,6 @@ Overlay : allways ***********************
 			}
 
 			.wp-block-navigation-item {
-				font-size: var(--wp--preset--font-size--x-small);
 				&__content {
 					font-weight: normal;
 				}
@@ -287,6 +286,14 @@ Overlay : allways ***********************
  *  Horizontal Navigation common styles
  */
  .wp-block-navigation:is(.is-horizontal) {
+	// 横メニューのサブメニューでのみ文字サイズが小さくなるように
+	&:where(:not(:has(.has-modal-open))) {
+		:where(.wp-block-navigation__submenu-container) {
+			:where(.wp-block-navigation-item) {
+				font-size: var(--wp--preset--font-size--x-small);
+			}
+		}
+	}
 	.wp-block-navigation-item__content {
 		padding-left: var(--nav-top-item-padding-horizontal);
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Bug Fix ][ Navigation Block ] Fixed an issue where overlay navigation items were displayed with x-small font size by limiting x-small font size to horizontal navigation submenu items only
+
 = 1.39.0 =
 [ New Feature ] Added "Navigation Overlay" template part area and a default overlay pattern for full-screen navigation
 [ Bug Fix ][ Navigation Block ] Fixed display issues on WordPress 7.0 ( updated selectors to handle the new submenu toggle button markup, cancelled the unwanted gap on always-open submenus, and adjusted padding for "Open on click" in the editor )


### PR DESCRIPTION
## 概要

オーバーレイナビゲーション（always open）内のナビゲーション項目にも `font-size: var(--wp--preset--font-size--x-small)` が適用されていたため、オーバーレイナビ項目が意図せず小さい文字サイズで表示されていた不具合を修正しました。

x-small フォントサイズの適用範囲を、横並びナビゲーション（`.is-horizontal`）のサブメニュー項目のみに限定するように変更しました。

## 変更内容

- `assets/_scss/_navigation.scss`
  - オーバーレイナビゲーション (`.wp-block-navigation__responsive-container.is-menu-open` 内の Always Open ブロック) の `.wp-block-navigation-item` から `font-size: var(--wp--preset--font-size--x-small);` を削除
  - `.wp-block-navigation:is(.is-horizontal)` 配下に、モーダル展開中ではないサブメニュー (`.wp-block-navigation__submenu-container` 内の `.wp-block-navigation-item`) に対してのみ `font-size: x-small` を適用するルールを追加

## 確認手順

### 前提条件

- X-T9 テーマを有効化
- ナビゲーションブロックを使用したヘッダーパターンが設定されていること（例: 1.39.0 で追加された Overlay パターン、または通常の横並びナビ）

### 手順

#### Before（修正前）

1. ヘッダーパターンとして「Navigation Overlay」（オーバーレイナビゲーション）を使用したサイトを開く
2. オーバーレイメニューを開く（ハンバーガーアイコンをクリック）
3. オーバーレイ内に表示されるナビゲーション項目の文字サイズを確認する
   → ✗ オーバーレイのナビゲーション項目が x-small サイズで小さく表示される

#### After（修正後）

1. ヘッダーパターンとして「Navigation Overlay」（オーバーレイナビゲーション）を使用したサイトを開く
2. オーバーレイメニューを開く（ハンバーガーアイコンをクリック）
3. オーバーレイ内に表示されるナビゲーション項目の文字サイズを確認する
   → ✓ ナビゲーション項目が通常サイズで表示される（x-small が適用されない）
4. 横並びナビゲーション（`.is-horizontal`）が含まれるページを開く
5. サブメニューを持つトップレベル項目にカーソルを合わせる
6. 表示されるサブメニュー項目の文字サイズを確認する
   → ✓ サブメニュー項目は引き続き x-small サイズで表示される（デグレなし）
7. 横並びナビゲーションのトップレベル項目の文字サイズを確認する
   → ✓ 通常サイズのまま（デグレなし）

## スクリーンショット

### Before

（オーバーレイナビゲーション項目が x-small で小さく表示）

### After

（オーバーレイナビゲーション項目が通常サイズで表示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ナビゲーションブロックのオーバーレイナビゲーション項目が不適切に小さく表示される不具合を修正しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/x-t9/pull/450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->