### PR TITLE
[ 機能追加 ] WordPress 7.0 から導入されたテキストカラムをサポート

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ New Feature ] Added support for the text columns feature introduced in WordPress 7.0
+
 = 1.39.2 =
 [ Specification Change ] Updated WordPress version requirement to 7.0 or higher (Requires at least: 6.5 → 7.0, Tested up to: 6.9 → 7.0)
 

--- a/theme.json
+++ b/theme.json
@@ -168,6 +168,7 @@
 				"minViewportWidth": "360px",
 				"maxViewportWidth": "1200px"
 			},
+			"textColumns": true,
 			"writingMode": true,
 			"defaultFontSizes": false,
 			"fontFamilies": [


### PR DESCRIPTION
## 概要

WordPress 7.0 から `settings.typography.textColumns` が追加されました。本 PR で theme.json の typography 設定に `textColumns: true` を追加し、ブロックエディター上でテキストの段組み（マルチカラム）コントロールを利用できるようにします。

## 変更内容

- `theme.json` の `settings.typography` に `textColumns: true` を追加

## 確認手順

### 前提条件

- WordPress 7.0 以上
- X-T9 テーマを有効化

### 手順

1. WordPress 管理画面で固定ページまたは投稿の編集画面を開く
2. 段落ブロックを追加し、複数行になる程度のテキストを入力する
3. 段落ブロックを選択した状態でサイドバーの「タイポグラフィ」パネル右上の「+」（オプション）から「テキストの段組み」を有効化する
4. 表示された「テキストの段組み」コントロールで段数（例: `2`）を指定する
   → ✓ エディター上でテキストが2段組みで表示される
5. 投稿を公開（または更新）してフロント側を確認する
   → ✓ 公開側でも同様にテキストが2段組みで表示される
6. 段組み設定を空欄に戻して保存
   → ✓ 段組みが解除され、通常の1段表示に戻る（デグレなし）

## スクリーンショット

省略可（theme.json 上で UI 機能を有効化するのみで、新規 UI を独自実装したものではないため）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * WordPress 7.0 で導入されたテキスト列機能に対応しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/x-t9/pull/451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->