### PR TITLE
[ 不具合修正 ][ ナビゲーションブロック ] サブメニューの詳細度が高すぎてカスタマイズに影響が出る不具合を修正

### DIFF
--- a/assets/_scss/_navigation.scss
+++ b/assets/_scss/_navigation.scss
@@ -313,18 +313,18 @@ Overlay : allways ***********************
 	& > .wp-block-navigation__container,
 	// レスポンシブコンテナ内（PC用）のみ
 	.wp-block-navigation__container.is-responsive {
-		.wp-block-navigation__submenu-container{
+		:where(.wp-block-navigation__submenu-container){
 			&.has-vk-color-primary-background-color{ // Adjusted to override WordPress core CSS. (for VK Pattern Library)
 				background-color: var(--wp--preset--color--primary);
 			}
 			&:where(:not(.has-background)) {
-				.wp-block-navigation-item {
+				:where(.wp-block-navigation-item) {
 					background-color: var(--wp--preset--color--primary);
 				}
 			}
-			.wp-block-navigation-item {
+			:where(.wp-block-navigation-item) {
 				border-bottom: 1px solid var(--wp--preset--color--border-normal-darkbg);
-				&:hover {
+				&:where(:hover) {
 					background-color: var(--wp--preset--color--primary-hover);
 				}
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
-[ Spec Change ][ Navigation Block ] Lowered CSS specificity of submenu container styles using :where() to allow easier style overrides from the site editor
+[ Spec Change ][ Navigation Block ] Lowered CSS specificity of submenu container with :where() to allow style overrides
 
 = 1.39.2 =
 [ Specification Change ] Updated WordPress version requirement to 7.0 or higher (Requires at least: 6.5 → 7.0, Tested up to: 6.9 → 7.0)

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
-[ Spec Change ][ Navigation Block ] Lowered CSS specificity of submenu container with :where() to allow style overrides
+[ Bug Fix ][ Navigation Block ] Fixed an issue where high CSS specificity of submenu styles affected customization
 
 = 1.39.2 =
 [ Specification Change ] Updated WordPress version requirement to 7.0 or higher (Requires at least: 6.5 → 7.0, Tested up to: 6.9 → 7.0)

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Spec Change ][ Navigation Block ] Lowered CSS specificity of submenu container styles using :where() to allow easier style overrides from the site editor
+
 = 1.39.2 =
 [ Specification Change ] Updated WordPress version requirement to 7.0 or higher (Requires at least: 6.5 → 7.0, Tested up to: 6.9 → 7.0)
 


### PR DESCRIPTION
:where() でサブメニューコンテナのCSS詳細度を下げてスタイル上書きを可能化

## 概要

ナビゲーションブロックのサブメニューコンテナおよび内部のナビゲーションアイテムに対するセレクタを `:where()` でラップし、CSS の詳細度を下げました。サイトエディタやユーザー独自のカスタム CSS から、これらのスタイルをより容易に上書きできるようになります。

## 変更内容

`assets/_scss/_navigation.scss` の以下のセレクタを `:where()` でラップ:

- `.wp-block-navigation__submenu-container` → `:where(.wp-block-navigation__submenu-container)`
- `.wp-block-navigation-item`（2箇所）→ `:where(.wp-block-navigation-item)`
- `&:hover` → `&:where(:hover)`

対象範囲: `.wp-block-navigation__container`（ブロック直下、またはレスポンシブコンテナ内 PC 用）配下のサブメニュー色指定（背景色・ボーダー・ホバー色）

## 確認手順

### 前提条件
- フルサイト編集対応のテーマ環境（X-T9）
- ナビゲーションブロックを配置したヘッダーテンプレートまたはパターン
- サブメニューを持つメニュー項目があること

### 手順

1. 管理画面 > 外観 > エディター でテンプレート/テンプレートパーツを開く
2. ナビゲーションブロックを配置し、サブメニュー付きの項目を追加する
3. 公開側を表示してデスクトップ表示でサブメニューを開く
   → ✓ サブメニュー背景色・ボーダー・ホバー時の色がこれまで通り表示される（デグレなし）
4. レスポンシブコンテナの PC 表示時も同様に確認
   → ✓ サブメニューの表示がこれまで通り
5. グローバルスタイルまたは追加 CSS から `.wp-block-navigation__submenu-container { background-color: ... }` のようにシンプルなセレクタで色を上書きする
   → ✓ 詳細度の低下により、ユーザー側のシンプルな指定が反映されやすくなっている

### デグレ確認
- サブメニューの背景色（primary 色）が変わっていないこと
- サブメニュー項目のボーダー（border-bottom）が表示されていること
- ホバー時の色変化（primary-hover）が機能していること
- `.has-vk-color-primary-background-color` クラスを付けたサブメニューの背景色が引き続き primary 色になること

## スクリーンショット

表示自体はこれまで通りのため、見た目の Before / After は同一になります（必要に応じてレビュー時に添付します）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル改善**
  * ナビゲーションブロックのサブメニューコンテナのスタイル適用が改善されました。サイトエディタからのスタイルカスタマイズがより容易になります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/x-t9/pull/452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->