### PR TITLE
[ デザイン不具合修正 ][ ボタン ] アウトラインスタイルのボタンの文字色が白くなり見えなくなる不具合を修正

### DIFF
--- a/assets/_scss/_button.scss
+++ b/assets/_scss/_button.scss
@@ -17,9 +17,6 @@ input[type='submit'],
 	:root & {
 		text-decoration: none;
 	}
-	:root &:not(.is-style-outline) {
-		color: #fff; // BG Secondary and Dark both white
-	}
 }
 .wp-block-search__button{
 	white-space: nowrap;
@@ -43,11 +40,8 @@ input[type='submit'],
 		background-color:transparent;
 		color: currentColor;
 	}
-	& > .wp-block-button__link:not(.has-background):hover {
+	& > .wp-block-button__link:hover {
 		background-color: var(--wp--preset--color--primary-hover);
-		color: #fff;
-	}
-	& > .has-text-color:where(:not(.has-background)):hover {
 		color:#fff !important;
 	}
 }


### PR DESCRIPTION
## 概要

アウトラインスタイルのボタン（`.wp-block-button.is-style-outline`）で、文字色が白になってしまい背景が明るい場面で見えなくなる不具合を修正します。

`assets/_scss/_button.scss` を以下のように調整しています。

- 非アウトラインボタンに白文字を強制していた `:root &:not(.is-style-outline) { color: #fff }` を削除（未リリースの #431 で追加された記述）
- アウトラインボタンの hover スタイルを `& > .wp-block-button__link:hover` に一本化し、`:not(.has-background)` / `.has-text-color:where(...)` で分岐していた白文字指定を整理

## 確認手順

### 前提条件
- テーマ「X-T9」を有効化
- 投稿または固定ページの編集画面

### Before（修正前の再現）
1. ボタンブロックを追加し、スタイルを「アウトライン」に設定する
2. テキスト色をプライマリー以外（または未指定）にする
3. 公開／プレビューでボタンを確認する、またはボタンにホバーする
   → ✗ 文字色が白になり、明るい背景では文字が見えなくなる

### After（修正後）
1. 同様にアウトラインスタイルのボタンを配置する
2. テキスト色をプライマリー以外（または未指定）にする
3. 公開／プレビューで確認・ホバーする
   → ✓ 文字色が白に潰れず、ボーダー／テキストが視認できる
4. ソリッド（塗り）ボタン、検索ボタン等の既存スタイルを確認する
   → ✓ 既存ボタンの表示に影響がない（デグレなし）

## スクリーンショット

表示（色）の変更のため、アウトラインボタンの Before / After スクリーンショットを添付してください。

### Before
（文字色が白で見えない状態）

### After
（文字色が視認できる状態）

## 補足

- 本修正は未リリースの #431（アウトラインボタン文字色の不具合修正）に対するフォローアップ調整であり、1.40.0 リリース済みの挙動として新規に生じた不具合ではないため、**changelog への追記は行っていません**（未リリース機能の不具合修正のため）。
- `assets/css/` は `.gitignore` 対象（ビルド成果物）のため、コミットには SCSS ソースのみ含まれます。
- CSS のみの変更のため PHPUnit テストは追加していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * ボタンのスタイリングを更新しました。
  * ボタンのホバー時の動作を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->