### PR TITLE
[ デザイン不具合修正 ][ ナビゲーションブロック ] 暗い背景のオーバーレイメニュー背景が白くなる不具合を修正

### DIFF
--- a/assets/_scss/_navigation.scss
+++ b/assets/_scss/_navigation.scss
@@ -286,7 +286,7 @@ Overlay : allways ***********************
 	// モーダル背景白 / 文字色白 になってしまう不具合があるため、モーダル背景を上書き
 	// ※ オーバーレイテンプレートの場合はそちらで直接色指定すればいいのでこちらでは指定しない
 	.has-bg-dark-background-color &.wp-block-navigation__responsive-container.is-menu-open:not(.disable-default-overlay) {
-	    background-color: var(--wp--preset--color--bg-dark);
+		background-color: var(--wp--preset--color--bg-dark);
 	}
 }
 

--- a/assets/_scss/_navigation.scss
+++ b/assets/_scss/_navigation.scss
@@ -280,6 +280,14 @@ Overlay : allways ***********************
 			}
 		}
 	}
+
+	// ナビ背景色がない場合に、コアがモーダルの背景に白を指定してくるため、
+	// フッターなど親要素の背景が暗くて文字色を白に指定している場合に、
+	// モーダル背景白 / 文字色白 になってしまう不具合があるため、モーダル背景を上書き
+	// ※ オーバーレイテンプレートの場合はそちらで直接色指定すればいいのでこちらでは指定しない
+	.has-bg-dark-background-color &.wp-block-navigation__responsive-container.is-menu-open:not(.disable-default-overlay) {
+	    background-color: var(--wp--preset--color--bg-dark);
+	}
 }
 
 /****************************************************** 

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Bug Fix ][ Navigation Block ] Fixed an issue where the overlay menu background turned white over a dark footer background, making the white menu text unreadable
 [ Spec Change ] Added a hover underline to post titles and the Read More button within the Query Loop block, and removed the top margin of post titles
 [ Spec Change ] Moved block patterns to the WordPress standard /patterns directory so they are auto-registered by core ( previously registered via register_block_pattern() from /inc/patterns )
 [ Spec Change ] Show only the theme's own block patterns in the block inserter by disabling the core bundled patterns and the WordPress.org remote pattern directory


### PR DESCRIPTION
## 概要

ナビゲーションに背景色が指定されていない場合、コアがオーバーレイ（モーダル）メニューの背景に白を指定するため、フッターなど親要素の背景が暗く文字色を白にしているケースで「背景白 / 文字白」となりメニュー項目が読めなくなる不具合を修正します。

`.has-bg-dark-background-color` 配下でモーダルが開いた際に、モーダル背景を `--wp--preset--color--bg-dark` で上書きします。オーバーレイテンプレートを使用する場合はそちら側で色指定できるため、`:not(.disable-default-overlay)` で対象外にしています。

## 変更ファイル
- `assets/_scss/_navigation.scss`

## 確認手順

### 前提条件
- x-t9 テーマ有効化。暗い背景（`bg-dark`）のフッター等にナビゲーションブロックを配置し、メニュー文字色を白に設定。ナビゲーション自体には背景色を指定しない。

### 手順

#### Before（修正前の再現手順）
1. 暗い背景のフッター内ナビでハンバーガー（モーダル）メニューを開く
   → ✗ モーダル背景が白くなり、白い文字が読めない

#### After（修正後）
1. 同じ条件でモーダルメニューを開く
   → ✓ モーダル背景が `bg-dark` 色になり、白文字が読める
2. ナビに独自の背景色を指定した場合に開く
   → ✓ 従来どおり指定した背景色が維持される（デグレなし）
3. オーバーレイテンプレート（`disable-default-overlay`）を使うナビで開く
   → ✓ この上書きの影響を受けず、テンプレート側の色指定が効く

## スクリーンショット

### Before
（修正前: モーダル背景が白で白文字が読めない状態）

### After
（修正後: モーダル背景が暗色で白文字が読める状態）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **バグ修正**
  * ナビゲーションブロックのモーダルオーバーレイがダーク背景上で適切に表示されるよう改善しました。暗いフッターやテーマ環境でもメニュー文字が正しく表示され、読みやすくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->