### PR TITLE
[ デザイン不具合修正 ][ ナビゲーションブロック ] text-inline スタイルのナビ項目の横パディングが消える不具合を修正

### DIFF
--- a/assets/_scss/_navigation_additional-class.scss
+++ b/assets/_scss/_navigation_additional-class.scss
@@ -118,8 +118,7 @@
 			}
 		}
 		:where( .wp-block-navigation-item__content ) {
-			padding-top: 0;
-			padding-bottom: 0;
+			padding: 0 var(--nav-top-item-padding-horizontal);
 		}
 	}
 

--- a/assets/_scss/editor.scss
+++ b/assets/_scss/editor.scss
@@ -75,6 +75,11 @@
 	}
 }
 
+// コアが padding:0 付けてきて余白がなくなるので上書き
+.wp-block-navigation[class*='nav--text-inline'] .wp-block-navigation-item.open-on-click button.wp-block-navigation-item__content:not(.wp-block-navigation-submenu__toggle){
+	padding-left: var(--nav-top-item-padding-horizontal);
+}
+
 /* group ------------------------------------------------- */
 *[class*="is-position-fixed"]{
 	width:100%;

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Bug Fix ][ Navigation Block ] Fixed an issue where the horizontal padding of text-inline style navigation items was lost ( restored on both the front-end and in the editor )
 [ Spec Change ] Added a hover underline to post titles and the Read More button within the Query Loop block, and removed the top margin of post titles
 [ Spec Change ] Moved block patterns to the WordPress standard /patterns directory so they are auto-registered by core ( previously registered via register_block_pattern() from /inc/patterns )
 [ Spec Change ] Show only the theme's own block patterns in the block inserter by disabling the core bundled patterns and the WordPress.org remote pattern directory


### PR DESCRIPTION
## 概要

text-inline スタイル（`nav--text-inline`）のナビゲーション項目で、左右のパディングが失われる不具合を修正します。フロント側・エディター側の両方で横パディングを復元します。

- フロント (`_navigation_additional-class.scss`): ナビ項目コンテンツの指定を `padding-top/bottom: 0` から `padding: 0 var(--nav-top-item-padding-horizontal)` に変更し、横パディングを付与
- エディター (`editor.scss`): コアが `nav--text-inline` の "Open on click" 項目に `padding: 0` を付与して余白が消えるため、`padding-left: var(--nav-top-item-padding-horizontal)` で上書き

## 変更ファイル
- `assets/_scss/_navigation_additional-class.scss`
- `assets/_scss/editor.scss`

## 確認手順

### 前提条件
- x-t9 テーマ有効化。ナビゲーションブロックに `nav--text-inline` スタイルを適用し、サブメニューを「クリックで開く（Open on click）」に設定。

### 手順

#### Before（修正前の再現手順）
1. フロントで text-inline ナビを表示する
   → ✗ ナビ項目の左右パディングがなく詰まって表示される
2. エディターで同ナビの "Open on click" 項目を確認する
   → ✗ 項目の左パディングが消えている

#### After（修正後）
1. フロントで text-inline ナビを表示する
   → ✓ 各項目に左右パディング（`--nav-top-item-padding-horizontal`）が付く
2. エディターで "Open on click" 項目を確認する
   → ✓ 左パディングが復元され、フロントと表示が揃う
3. text-inline 以外のナビスタイルを確認する
   → ✓ 影響を受けず従来どおり表示される（デグレなし）

## スクリーンショット

### Before
（修正前: 項目の横パディングが消えている状態）

### After
（修正後: 横パディングが復元された状態）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリース ノート

* **Bug Fixes**
  * ナビゲーション ブロックの text-inline スタイルにおいて、ナビゲーション項目の横方向パディングが失われる問題を修正しました。フロントエンドとエディターの両環境で正しく表示されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->