### PR TITLE
[ 仕様変更 ] ブロックパターンのデザイン微調整と queryId 除去

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,6 +55,17 @@ const dynamicReplacements = [
 				.replace( /,\}/, '}' );       // ref が末尾だった場合のダンギングカンマを修正
 		},
 	],
+	// wp:query 内の "queryId":数字 を削除（サイト個別に採番される ID を本番に持ち込まない）。
+	// wp:query の開始タグに限定して処理することで、別ブロックの同名属性を誤って削除しないようにする。
+	[
+		/<!-- wp:query \{[\s\S]*?-->/g,
+		function ( tag ) {
+			return tag
+				.replace( /"queryId":\d+,?/, '' ) // queryId 属性を除去
+				.replace( /\{,/, '{' )            // queryId が先頭だった場合の余分なカンマを修正
+				.replace( /,\}/, '}' );           // queryId が末尾だった場合のダンギングカンマを修正
+		},
+	],
 ];
 
 // 要素テキスト（>ラベル</）を翻訳関数へ置換する対象ラベル。

--- a/patterns/footer-bg-dark-3col.php
+++ b/patterns/footer-bg-dark-3col.php
@@ -55,7 +55,7 @@
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 
-<!-- wp:query {"queryId":1,"query":{"perPage":"5","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]}} -->
+<!-- wp:query {"query":{"perPage":"5","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
 <!-- wp:spacer {"className":"is-style-spacer-xs"} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xs"></div>

--- a/patterns/footer-bg-dark.php
+++ b/patterns/footer-bg-dark.php
@@ -12,13 +12,13 @@
  */
 
 ?>
-<!-- wp:group {"metadata":{"categories":["footer"],"patternName":"x-t9/footer-bg-dark","name":"Footer BG Dark"},"align":"full","className":"has-text-normal-darkbg-color has-text-color","style":{"border":{"top":{"color":"var:preset|color|primary","width":"2px"}},"spacing":{"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"bg-dark"} -->
+<!-- wp:group {"metadata":{"categories":["footer"],"name":"Footer BG Dark"},"align":"full","className":"has-text-normal-darkbg-color has-text-color","style":{"border":{"top":{"color":"var:preset|color|primary","width":"2px"}},"spacing":{"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"bg-dark"} -->
 <div class="wp-block-group alignfull has-text-normal-darkbg-color has-text-color has-bg-dark-background-color has-background" style="border-top-color:var(--wp--preset--color--primary);border-top-width:2px;margin-top:0;margin-bottom:0"><!-- wp:group {"style":{"spacing":{"padding":{"top":"1.5rem","bottom":"1.5rem"}}},"layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-top:1.5rem;padding-bottom:1.5rem"><!-- wp:image {"width":"180px","sizeSlug":"full","linkDestination":"media","align":"center"} -->
 <figure class="wp-block-image aligncenter size-full is-resized"><img src="<?php echo esc_url( get_template_directory_uri() ); ?>/inc/patterns/images/x-t9-logo-yoko-white-trans.png" alt="" style="width:180px"/></figure>
 <!-- /wp:image -->
 
-<!-- wp:social-links {"iconColorValue":"rgba( 255,255,255,0.6 )","openInNewTab":true,"size":"has-normal-icon-size","className":"is-style-logos-only","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|40","left":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:social-links {"iconColor":"text-normal-darkbg","iconColorValue":"rgba( 255,255,255,0.7 )","openInNewTab":true,"size":"has-normal-icon-size","className":"is-style-logos-only","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|40","left":"var:preset|spacing|40"},"margin":{"top":"var:preset|spacing|40"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
 <ul class="wp-block-social-links has-normal-icon-size has-icon-color is-style-logos-only" style="margin-top:var(--wp--preset--spacing--40)"><!-- wp:social-link {"url":"https://wordpress.org/","service":"facebook"} /-->
 
 <!-- wp:social-link {"url":"https://wordpress.org/","service":"x"} /-->

--- a/patterns/footer-bg-secondary-3col.php
+++ b/patterns/footer-bg-secondary-3col.php
@@ -55,7 +55,7 @@
 <!-- /wp:heading --></div>
 <!-- /wp:group -->
 
-<!-- wp:query {"queryId":1,"query":{"perPage":"5","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]}} -->
+<!-- wp:query {"query":{"perPage":"5","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
 <!-- wp:spacer {"className":"is-style-spacer-xs"} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer is-style-spacer-xs"></div>

--- a/patterns/post-list-large-image-left.php
+++ b/patterns/post-list-large-image-left.php
@@ -33,7 +33,7 @@
 <hr class="wp-block-separator has-text-color has-border-normal-color has-css-opacity has-border-normal-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 
-<!-- wp:query {"queryId":9,"query":{"perPage":"2","pages":"0","offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]},"layout":{"inherit":false}} -->
+<!-- wp:query {"query":{"perPage":"2","pages":"0","offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]},"layout":{"inherit":false}} -->
 <div class="wp-block-query"><!-- wp:post-template {"layout":{"type":"default","columnCount":3}} -->
 <!-- wp:columns {"verticalAlignment":"top","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} -->
 <div class="wp-block-columns are-vertically-aligned-top" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--50)"><!-- wp:column {"verticalAlignment":"top","width":"33.33%"} -->

--- a/patterns/post-list-text-inline-offset-up.php
+++ b/patterns/post-list-text-inline-offset-up.php
@@ -17,12 +17,12 @@
 <div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer is-style-spacer-lg"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:heading {"className":"vk_block-margin-0\u002d\u002dmargin-bottom is-style-vk-heading-plain","style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}},"typography":{"textAlign":"center"}},"anchor":"information"} -->
-<h2 class="wp-block-heading has-text-align-center vk_block-margin-0--margin-bottom is-style-vk-heading-plain" id="information" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50)"><?php echo esc_html__( 'Information', 'x-t9' ); ?></h2>
+<!-- wp:heading {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}},"typography":{"textAlign":"center"}},"anchor":"information"} -->
+<h2 class="wp-block-heading has-text-align-center" id="information" style="margin-top:0;margin-bottom:0"><?php echo esc_html__( 'Information', 'x-t9' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:paragraph {"className":"vk_block-margin-0\u002d\u002dmargin-top vk_block-margin-0\u002d\u002dmargin-bottom has-vk-color-primary-color has-text-color","style":{"typography":{"textAlign":"center"}},"textColor":"vk-color-primary","fontSize":"small"} -->
-<p class="has-text-align-center vk_block-margin-0--margin-top vk_block-margin-0--margin-bottom has-vk-color-primary-color has-text-color has-small-font-size">News / Blog</p>
+<!-- wp:paragraph {"style":{"typography":{"textAlign":"center"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"textColor":"primary","fontSize":"small"} -->
+<p class="has-text-align-center has-primary-color has-text-color has-small-font-size" style="margin-top:0;margin-bottom:0">News / Blog</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:spacer {"height":"var:preset|spacing|60","className":"is-style-spacer-lg"} -->
@@ -35,25 +35,25 @@
 <div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:query {"queryId":6,"query":{"perPage":"5","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]}} -->
+<!-- wp:query {"query":{"perPage":5,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]},"metadata":{"categories":["posts"],"name":"X-T9 Query (Post List) Text Inline","patternName":"x-t9/query-text-inline"}} -->
 <div class="wp-block-query"><!-- wp:separator {"className":"is-style-wide","backgroundColor":"border-normal"} -->
 <hr class="wp-block-separator has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 
-<!-- wp:post-template {"className":"vk_block-margin-0\u002d\u002dmargin-top","layout":{"type":"default"}} -->
-<!-- wp:spacer {"height":"var:preset|spacing|30","className":"is-style-spacer-xs"} -->
-<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer is-style-spacer-xs"></div>
+<!-- wp:post-template {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
+<!-- wp:spacer {"height":"var:preset|spacing|40","className":"is-style-default"} -->
+<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer is-style-default"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:columns {"className":"vk_block-margin-0\u002d\u002dmargin-bottom vk_block-margin-0\u002d\u002dmargin-top","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
-<div class="wp-block-columns vk_block-margin-0--margin-bottom vk_block-margin-0--margin-top"><!-- wp:column {"verticalAlignment":"center","width":"240px"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:240px"><!-- wp:columns {"isStackedOnMobile":false,"className":"vk_block-margin-0\u002d\u002dmargin-bottom","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|40","left":"1em"}}}} -->
-<div class="wp-block-columns is-not-stacked-on-mobile vk_block-margin-0--margin-bottom"><!-- wp:column {"verticalAlignment":"center","width":"130px"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:130px"><!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}},"textColor":"text-secondary","fontSize":"small"} /--></div>
+<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-columns"><!-- wp:column {"verticalAlignment":"center","width":"240px"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:240px"><!-- wp:columns {"isStackedOnMobile":false,"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|40","left":"1em"}}}} -->
+<div class="wp-block-columns is-not-stacked-on-mobile"><!-- wp:column {"verticalAlignment":"center","width":"140px"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:140px"><!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}},"textColor":"text-secondary","fontSize":"small"} /--></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"verticalAlignment":"center","width":"150px"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:150px"><!-- wp:post-terms {"term":"category","style":{"typography":{"textDecoration":"none"},"elements":{"link":{"color":{"text":"#333333"}}}},"fontSize":"small"} /--></div>
+<!-- wp:column {"verticalAlignment":"center","width":"160px"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:160px"><!-- wp:post-terms {"term":"category","style":{"typography":{"textDecoration":"none"},"elements":{"link":{"color":{"text":"#333333"}}}},"fontSize":"small"} /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
 <!-- /wp:column -->
@@ -63,12 +63,12 @@
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|30","className":"is-style-spacer-xs"} -->
-<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer is-style-spacer-xs"></div>
+<!-- wp:spacer {"height":"var:preset|spacing|40","className":"is-style-default"} -->
+<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer is-style-default"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:separator {"className":"is-style-wide vk_block-margin-0\u002d\u002dmargin-top vk_block-margin-0\u002d\u002dmargin-bottom","backgroundColor":"border-normal"} -->
-<hr class="wp-block-separator has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide vk_block-margin-0--margin-top vk_block-margin-0--margin-bottom"/>
+<!-- wp:separator {"className":"is-style-wide","backgroundColor":"border-normal"} -->
+<hr class="wp-block-separator has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- /wp:post-template -->
 
@@ -79,8 +79,8 @@
 <!-- /wp:query-no-results --></div>
 <!-- /wp:query -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|40","className":"is-style-spacer-sm"} -->
-<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer is-style-spacer-sm"></div>
+<!-- wp:spacer {"height":"var:preset|spacing|60","className":"is-style-spacer-md"} -->
+<div style="height:var(--wp--preset--spacing--60)" aria-hidden="true" class="wp-block-spacer is-style-spacer-md"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->

--- a/patterns/query-text-inline.php
+++ b/patterns/query-text-inline.php
@@ -17,15 +17,15 @@
 <hr class="wp-block-separator has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 
-<!-- wp:post-template {"className":"vk_block-margin-0\u002d\u002dmargin-top","layout":{"type":"default"}} -->
+<!-- wp:post-template {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 <!-- wp:spacer {"height":"var:preset|spacing|40","className":"is-style-default"} -->
 <div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer is-style-default"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:columns {"className":"vk_block-margin-0\u002d\u002dmargin-bottom vk_block-margin-0\u002d\u002dmargin-top","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|40"}}}} -->
-<div class="wp-block-columns vk_block-margin-0--margin-bottom vk_block-margin-0--margin-top"><!-- wp:column {"verticalAlignment":"center","width":"240px"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:240px"><!-- wp:columns {"isStackedOnMobile":false,"className":"vk_block-margin-0\u002d\u002dmargin-bottom","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|40","left":"1em"}}}} -->
-<div class="wp-block-columns is-not-stacked-on-mobile vk_block-margin-0--margin-bottom"><!-- wp:column {"verticalAlignment":"center","width":"140px"} -->
+<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-columns"><!-- wp:column {"verticalAlignment":"center","width":"240px"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:240px"><!-- wp:columns {"isStackedOnMobile":false,"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|40","left":"1em"}}}} -->
+<div class="wp-block-columns is-not-stacked-on-mobile"><!-- wp:column {"verticalAlignment":"center","width":"140px"} -->
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:140px"><!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}},"textColor":"text-secondary","fontSize":"small"} /--></div>
 <!-- /wp:column -->
 
@@ -44,8 +44,8 @@
 <div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer is-style-default"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:separator {"className":"is-style-wide vk_block-margin-0\u002d\u002dmargin-top vk_block-margin-0\u002d\u002dmargin-bottom","backgroundColor":"border-normal"} -->
-<hr class="wp-block-separator has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide vk_block-margin-0--margin-top vk_block-margin-0--margin-bottom"/>
+<!-- wp:separator {"className":"is-style-wide","backgroundColor":"border-normal"} -->
+<hr class="wp-block-separator has-text-color has-border-normal-color has-alpha-channel-opacity has-border-normal-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- /wp:post-template -->
 

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,10 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+= 1.41.1 =
+[ Spec Change ] Fine-tuned the spacing, column widths, and colors of the post list block patterns
+[ Spec Change ][ Query Loop Block ] Removed the site-specific queryId from Query Loop patterns so it is no longer included in the distributed patterns
+
 = 1.41.0 =
 [ Spec Change ][ Navigation Block ] Reworked dark-background color handling so links, text, and divider lines stay readable when a footer or other wrapper uses a dark background color
 [ New Feature ] Added block patterns ( Service Point, Service Flow, Pricing Plans, PR Contents, post list, and Query Loop patterns ) along with new "Post List Section", "Flow", and "Pricing" pattern categories


### PR DESCRIPTION
## 概要

ブロックパターンのデザインを微調整し、あわせて Query Loop 系パターンにサイト固有の `queryId` が埋め込まれないように整理しました。1.41.0 で追加したパターンの仕上げ調整です。

## 変更内容

### デザイン微調整
- **post-list-text-inline-offset-up.php**: 見出し・リード文のマージン制御を `vk_block-margin-*` クラスからブロック標準の `spacing.margin` に置き換え、投稿日／カテゴリーの列幅（130px→140px, 150px→160px）・スペーサー高さ・区切り線の余白を調整。リード文の色指定を `vk-color-primary` → コア標準の `primary` に変更。
- **query-text-inline.php**: 同様に `vk_block-margin-*` クラスをブロック標準の `spacing.margin` 指定へ統一。
- **footer-bg-dark.php**: ソーシャルリンクのアイコンカラーを `text-normal-darkbg`（不透明度 0.6 → 0.7）に調整し、暗背景での視認性を改善。グループの冗長な `patternName` メタデータを削除。

### queryId の除去
- 各パターンソース（footer-bg-dark-3col / footer-bg-secondary-3col / post-list-large-image-left / post-list-text-inline-offset-up）から、サイトごとに採番される `queryId` を削除。
- **gulpfile.js**: dist 生成時に `wp:query` 開始タグ内の `"queryId":数字` を自動除去する置換処理を追加。`wp:query` の開始タグに限定し、他ブロックの同名属性を誤って消さないようにしている。

## changelog

`readme.txt` に `= 1.41.1 =` セクションを追加（既存 changelog が全て英語のため英語で記載）。

## 確認手順

### 前提条件
- x-t9 テーマを有効化
- 投稿を 3 件以上作成（投稿日・カテゴリーが入っているもの）

### 手順
1. 投稿編集画面でブロックインサーター > パターンから「X-T9 Query (Post List) Text Inline」および「Information」セクションを含むパターンを挿入する
   → ✓ 投稿日・カテゴリー・タイトルが横並びで表示され、各列幅（投稿日 140px / カテゴリー 160px）・行間が整って表示される
   → ✓ 見出し・リード文の上下マージンが詰まりすぎ／空きすぎていない
2. フッターパターン「Footer BG Dark」を挿入し、公開側で確認する
   → ✓ 暗い背景上でソーシャルリンクのアイコンが視認できる
3. `npm run dist`（または該当の gulp タスク）で dist パッケージを生成し、パターン PHP を確認する
   → ✓ `wp:query` ブロックに `"queryId"` が含まれていない
   → ✓ `wp:query` 以外のブロック属性は変更されていない

## スクリーンショット

> ⚠️ 表示・レイアウトの変更を含むため、Before / After のスクリーンショットを添付してください（投稿リストパターンの列幅・余白、フッターのソーシャルリンク色）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * フッターおよびポストリストパターンの余白・カラム幅・配色を微調整しました。

* **Chores**
  * クエリロジックの内部構造を最適化しました。バージョン1.41.1をリリースします。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->