### PR TITLE
[ デザイン不具合修正 ] ブロックパターンの投稿タイトルから text-light クラスを除去しエディタの文字の太さ指定が効かない不具合を修正

### DIFF
--- a/patterns/footer-bg-dark-3col.php
+++ b/patterns/footer-bg-dark-3col.php
@@ -67,7 +67,7 @@
 <!-- wp:group {"layout":{"type":"default"}} -->
 <div class="wp-block-group"><!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}},"textColor":"text-secondary-darkbg","fontSize":"x-small"} /-->
 
-<!-- wp:post-title {"level":6,"isLink":true,"className":"text-light ","fontSize":"small"} /--></div>
+<!-- wp:post-title {"level":6,"isLink":true,"fontSize":"small"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/patterns/footer-bg-secondary-3col.php
+++ b/patterns/footer-bg-secondary-3col.php
@@ -67,7 +67,7 @@
 <!-- wp:group {"layout":{"type":"default"}} -->
 <div class="wp-block-group"><!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}},"textColor":"text-secondary","fontSize":"x-small"} /-->
 
-<!-- wp:post-title {"level":6,"isLink":true,"className":"text-light ","fontSize":"small"} /--></div>
+<!-- wp:post-title {"level":6,"isLink":true,"fontSize":"small"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/patterns/post-list-text-inline-offset-up.php
+++ b/patterns/post-list-text-inline-offset-up.php
@@ -59,7 +59,7 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":""} -->
-<div class="wp-block-column is-vertically-aligned-center"><!-- wp:post-title {"level":6,"isLink":true,"className":"text-light ","style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"elements":{"link":{"color":{"text":"#333333"}}},"color":{"text":"#333333"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"small"} /--></div>
+<div class="wp-block-column is-vertically-aligned-center"><!-- wp:post-title {"level":6,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"elements":{"link":{"color":{"text":"#333333"}}},"color":{"text":"#333333"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"small"} /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 

--- a/patterns/post-template-subcontent.php
+++ b/patterns/post-template-subcontent.php
@@ -22,7 +22,7 @@
 <!-- wp:group {"layout":{"type":"default"}} -->
 <div class="wp-block-group"><!-- wp:post-date {"textColor":"text-secondary-darkbg","fontSize":"x-small"} /-->
 
-<!-- wp:post-title {"level":6,"isLink":true,"className":"text-light ","fontSize":"small"} /--></div>
+<!-- wp:post-title {"level":6,"isLink":true,"fontSize":"small"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/patterns/query-image-grid.php
+++ b/patterns/query-image-grid.php
@@ -32,7 +32,7 @@
 <div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer is-style-default"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:post-title {"level":6,"isLink":true,"className":"text-light ","style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"elements":{"link":{"color":{"text":"#333333"}}},"color":{"text":"#333333"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"medium"} /-->
+<!-- wp:post-title {"level":6,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"elements":{"link":{"color":{"text":"#333333"}}},"color":{"text":"#333333"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"medium"} /-->
 
 <!-- wp:spacer {"height":"var:preset|spacing|40","className":"is-style-default"} -->
 <div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer is-style-default"></div>

--- a/patterns/query-subcontent.php
+++ b/patterns/query-subcontent.php
@@ -24,7 +24,7 @@
 <!-- wp:group {"layout":{"type":"default"}} -->
 <div class="wp-block-group"><!-- wp:post-date {"textColor":"text-secondary","fontSize":"x-small"} /-->
 
-<!-- wp:post-title {"level":6,"isLink":true,"className":"text-light ","fontSize":"small"} /--></div>
+<!-- wp:post-title {"level":6,"isLink":true,"fontSize":"small"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/patterns/query-text-inline.php
+++ b/patterns/query-text-inline.php
@@ -36,7 +36,7 @@
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":""} -->
-<div class="wp-block-column is-vertically-aligned-center"><!-- wp:post-title {"level":6,"isLink":true,"className":"text-light ","style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"elements":{"link":{"color":{"text":"#333333"}}},"color":{"text":"#333333"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"small"} /--></div>
+<div class="wp-block-column is-vertically-aligned-center"><!-- wp:post-title {"level":6,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"elements":{"link":{"color":{"text":"#333333"}}},"color":{"text":"#333333"},"spacing":{"margin":{"top":"0","bottom":"0"}}},"fontSize":"small"} /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Bug Fix ] Removed the text-light class from post titles in block patterns so the font weight set in the editor is no longer overridden by its font-weight: lighter !important
+
 = 1.41.1 =
 [ Spec Change ] Fine-tuned the spacing, column widths, and colors of the post list block patterns
 [ Spec Change ][ Query Loop Block ] Removed the site-specific queryId from Query Loop patterns so it is no longer included in the distributed patterns


### PR DESCRIPTION
## 概要

7 つのブロックパターンの投稿タイトル（post-title ブロック）から `"className":"text-light "` を除去しました。

`.text-light` は `_ulitilies.scss` で `font-weight: lighter !important;` を当てるクラスです。`!important` が付いているため、ブロックエディタのタイポグラフィ設定で投稿タイトルの文字の太さ（font-weight）を指定しても上書きされて効かない、という問題がありました。対象パターンから `text-light` クラスを除去し、エディタで指定した文字の太さが正しく反映されるようにしました。

```scss
.text-light {
	font-weight: lighter !important;
}
```

## 変更ファイル

- `patterns/footer-bg-dark-3col.php`
- `patterns/footer-bg-secondary-3col.php`
- `patterns/post-list-text-inline-offset-up.php`
- `patterns/post-template-subcontent.php`
- `patterns/query-image-grid.php`
- `patterns/query-subcontent.php`
- `patterns/query-text-inline.php`

## 確認手順

### Before（修正前の再現）

1. 投稿エディタで対象パターン（例: `query-image-grid`、`query-text-inline`）を挿入する
2. 投稿タイトル（post-title）ブロックを選択し、サイドバーの「タイポグラフィ」→「外観（Appearance / 太さ）」を Bold など太めに変更する
   → `font-weight: lighter !important` に上書きされ、文字の太さが変わらない

### After（修正後の確認）

1. 同じパターンを挿入し、同様に投稿タイトルの太さを変更する
   → エディタで指定した太さが反映される
2. 太さを未指定（デフォルト）に戻す
   → パターン本来の見た目になること（デグレなし）

### Before / After

文字の太さの見た目が変わるため、対象パターンの Before / After スクリーンショットを添付してください（同じ画面・同じ条件で撮影）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
