### PR TITLE
[ デザイン不具合修正 ][ Snow Monkey Forms ] BG Black 等のダークパレット選択時にフォームの文字色が白くなって見えなくなる不具合を修正

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -30,7 +30,9 @@ if ( ! function_exists( 'xt9_support' ) ) :
 			add_editor_style( 'assets/css/editor-wp65.css' );
 		}
 
+		// Load editor CSS for Snow Monkey Forms only when the plugin is active.
 		// Snow Monkey Forms が有効な場合のみエディタ用 CSS を読み込む。
+		// class_exists() is safe here because after_setup_theme fires after plugins_loaded.
 		// after_setup_theme 時点では plugins_loaded 済みのため class_exists で判定可能。
 		if ( class_exists( 'Snow_Monkey\Plugin\Forms\Bootstrap' ) ) {
 			add_editor_style( 'plugin-support/snow-monkey-forms/css/smf-editor.css' );

--- a/functions.php
+++ b/functions.php
@@ -30,6 +30,12 @@ if ( ! function_exists( 'xt9_support' ) ) :
 			add_editor_style( 'assets/css/editor-wp65.css' );
 		}
 
+		// Snow Monkey Forms が有効な場合のみエディタ用 CSS を読み込む。
+		// after_setup_theme 時点では plugins_loaded 済みのため class_exists で判定可能。
+		if ( class_exists( 'Snow_Monkey\Plugin\Forms\Bootstrap' ) ) {
+			add_editor_style( 'plugin-support/snow-monkey-forms/css/smf-editor.css' );
+		}
+
 		// Show only this theme's own block patterns in the inserter.
 		// Disable the core bundled patterns and the WordPress.org remote pattern
 		// directory so the inserter is not cluttered with unrelated patterns.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"build:script": "webpack --config webpack.js",
 		"sass": "sass --no-source-map assets/_scss/:assets/_scss/",
 		"sass:woocommerce": "sass --no-source-map --style=compressed plugin-support/woocommerce/_scss/woo.scss:plugin-support/woocommerce/css/woo.css",
-		"sass:snow-monkey-forms": "sass --no-source-map --style=compressed plugin-support/snow-monkey-forms/_scss/smf.scss:plugin-support/snow-monkey-forms/css/smf.css",
+		"sass:snow-monkey-forms": "sass --no-source-map --style=compressed plugin-support/snow-monkey-forms/_scss/smf.scss:plugin-support/snow-monkey-forms/css/smf.css plugin-support/snow-monkey-forms/_scss/smf-editor.scss:plugin-support/snow-monkey-forms/css/smf-editor.css",
 		"postcss:autoprefix": "npx postcss assets/_scss/*.css --use autoprefixer -r --no-map",
 		"postcss:minify": "npx postcss assets/_scss/*.css --use postcss-minify -d assets/css/ --no-map",
 		"postcss:all": "npx postcss assets/_scss/*.css --use autoprefixer postcss-minify -d assets/css/ --no-map",

--- a/plugin-support/snow-monkey-forms/_scss/smf-editor.scss
+++ b/plugin-support/snow-monkey-forms/_scss/smf-editor.scss
@@ -8,13 +8,13 @@
  * theme.json の styles.color.text によりエディタ iframe の body に
  * BG Black 等のダークパレット選択時は color: #fff が適用される。
  * SMF の編集パネルは白背景を前提とした設計のため、body の文字色を
- * 継承すると白文字になって見えなくなる。revert でブラウザ既定値に戻す。
+ * 継承すると白文字になって見えなくなる。initial でCSSの初期値に戻す。
  */
 .editor-styles-wrapper .snow-monkey-forms-setting-panel {
-	color: revert;
+	color: initial;
 }
 
-.editor-styles-wrapper .smf-item label,
+.editor-styles-wrapper .smf-item__label,
 .editor-styles-wrapper .smf-item .smf-item__description {
-	color: revert;
+	color: initial;
 }

--- a/plugin-support/snow-monkey-forms/_scss/smf-editor.scss
+++ b/plugin-support/snow-monkey-forms/_scss/smf-editor.scss
@@ -18,3 +18,15 @@
 .editor-styles-wrapper .smf-item .smf-item__description {
 	color: initial;
 }
+
+/*
+ * エディタの style.css（_common.scss）が
+ *   input:where(:not([type="submit"])) { color: var(--wp--preset--color--text-normal) }
+ * を適用するため、ダークパレット選択時に SMF の date / month 等の input が白文字になる。
+ * smf.scss 側（フロントエンド）は color: var(--_color-text, #333) で上書き済みだが、
+ * smf.scss はエディタには読み込まれないため、エディタ用に同等の上書きが必要。
+ * initial を使って CSS の初期値に戻し、inherit による文字色汚染を断ち切る。
+ */
+.editor-styles-wrapper .smf-form .smf-text-control__control {
+	color: initial;
+}

--- a/plugin-support/snow-monkey-forms/_scss/smf-editor.scss
+++ b/plugin-support/snow-monkey-forms/_scss/smf-editor.scss
@@ -10,8 +10,7 @@
  * SMF の編集パネルは白背景を前提とした設計のため、body の文字色を
  * 継承すると白文字になって見えなくなる。revert でブラウザ既定値に戻す。
  */
-.editor-styles-wrapper .snow-monkey-forms-setting-panel,
-.editor-styles-wrapper .snow-monkey-forms-setting-panel * {
+.editor-styles-wrapper .snow-monkey-forms-setting-panel {
 	color: revert;
 }
 

--- a/plugin-support/snow-monkey-forms/_scss/smf-editor.scss
+++ b/plugin-support/snow-monkey-forms/_scss/smf-editor.scss
@@ -1,0 +1,21 @@
+@charset "utf-8";
+
+/* ------------------------------------------- */
+/* Snow Monkey Forms - Editor                  */
+/* ------------------------------------------- */
+
+/*
+ * theme.json の styles.color.text によりエディタ iframe の body に
+ * BG Black 等のダークパレット選択時は color: #fff が適用される。
+ * SMF の編集パネルは白背景を前提とした設計のため、body の文字色を
+ * 継承すると白文字になって見えなくなる。revert でブラウザ既定値に戻す。
+ */
+.editor-styles-wrapper .snow-monkey-forms-setting-panel,
+.editor-styles-wrapper .snow-monkey-forms-setting-panel * {
+	color: revert;
+}
+
+.editor-styles-wrapper .smf-item label,
+.editor-styles-wrapper .smf-item .smf-item__description {
+	color: revert;
+}

--- a/plugin-support/snow-monkey-forms/_scss/smf.scss
+++ b/plugin-support/snow-monkey-forms/_scss/smf.scss
@@ -15,3 +15,21 @@
 .smf-form .smf-select-control__control {
 	background-image: none;
 }
+
+/*
+ * Snow Monkey Forms form controls always use white background (--_color-white).
+ * The theme sets color: text-normal (= #fff in BG Black palette) on input/textarea/select,
+ * making text invisible on the white control background.
+ * Override with SMF's own --_color-text (#333) which is designed for white backgrounds.
+ * SMF フォームコントロールは常に白背景（--_color-white）を使用する。
+ * テーマが BG Black パレット時に text-normal = #fff を設定するため
+ * 白背景のコントロール上でテキストが見えなくなる。
+ * SMF 自身の --_color-text（#333, 白背景向け）で上書きする。
+ */
+.smf-form {
+	.smf-text-control__control,
+	.smf-textarea-control__control,
+	.smf-select-control__control {
+		color: var(--_color-text, #333);
+	}
+}

--- a/plugin-support/snow-monkey-forms/css/smf-editor.css
+++ b/plugin-support/snow-monkey-forms/css/smf-editor.css
@@ -1,0 +1,1 @@
+.editor-styles-wrapper .snow-monkey-forms-setting-panel,.editor-styles-wrapper .snow-monkey-forms-setting-panel *{color:revert}.editor-styles-wrapper .smf-item label,.editor-styles-wrapper .smf-item .smf-item__description{color:revert}

--- a/plugin-support/snow-monkey-forms/css/smf-editor.css
+++ b/plugin-support/snow-monkey-forms/css/smf-editor.css
@@ -1,1 +1,1 @@
-.editor-styles-wrapper .snow-monkey-forms-setting-panel{color:revert}.editor-styles-wrapper .smf-item label,.editor-styles-wrapper .smf-item .smf-item__description{color:revert}
+.editor-styles-wrapper .snow-monkey-forms-setting-panel{color:initial}.editor-styles-wrapper .smf-item__label,.editor-styles-wrapper .smf-item .smf-item__description{color:initial}

--- a/plugin-support/snow-monkey-forms/css/smf-editor.css
+++ b/plugin-support/snow-monkey-forms/css/smf-editor.css
@@ -1,1 +1,1 @@
-.editor-styles-wrapper .snow-monkey-forms-setting-panel{color:initial}.editor-styles-wrapper .smf-item__label,.editor-styles-wrapper .smf-item .smf-item__description{color:initial}
+.editor-styles-wrapper .snow-monkey-forms-setting-panel{color:initial}.editor-styles-wrapper .smf-item__label,.editor-styles-wrapper .smf-item .smf-item__description{color:initial}.editor-styles-wrapper .smf-form .smf-text-control__control{color:initial}

--- a/plugin-support/snow-monkey-forms/css/smf-editor.css
+++ b/plugin-support/snow-monkey-forms/css/smf-editor.css
@@ -1,1 +1,1 @@
-.editor-styles-wrapper .snow-monkey-forms-setting-panel,.editor-styles-wrapper .snow-monkey-forms-setting-panel *{color:revert}.editor-styles-wrapper .smf-item label,.editor-styles-wrapper .smf-item .smf-item__description{color:revert}
+.editor-styles-wrapper .snow-monkey-forms-setting-panel{color:revert}.editor-styles-wrapper .smf-item label,.editor-styles-wrapper .smf-item .smf-item__description{color:revert}

--- a/plugin-support/snow-monkey-forms/css/smf.css
+++ b/plugin-support/snow-monkey-forms/css/smf.css
@@ -1,1 +1,1 @@
-.smf-form .smf-select-control__control{background-image:none}
+.smf-form .smf-select-control__control{background-image:none}.smf-form .smf-text-control__control,.smf-form .smf-textarea-control__control,.smf-form .smf-select-control__control{color:var(--_color-text, #333)}

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+* [ Design Bug Fix ][ Snow Monkey Forms ] Fixed an issue where form labels and description text in the Snow Monkey Forms editing panel turned white and became invisible when a dark palette such as BG Black was selected
+
 = 1.41.2 =
 [ Design Bug Fix ] Removed the text-light class from post titles in block patterns so the font weight set in the editor is no longer overridden by its font-weight: lighter !important
 

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
-* [ Design Bug Fix ][ Snow Monkey Forms ] Fixed an issue where form labels and description text in the Snow Monkey Forms editing panel turned white and became invisible when a dark palette such as BG Black was selected
+* [ Design Bug Fix ][ Snow Monkey Forms ] Fixed form labels in the editor turning white and invisible when a dark palette such as BG Black is selected
 
 = 1.41.2 =
 [ Design Bug Fix ] Removed the text-light class from post titles in block patterns so the font weight set in the editor is no longer overridden by its font-weight: lighter !important

--- a/readme.txt
+++ b/readme.txt
@@ -13,8 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
-* [ Design Bug Fix ][ Snow Monkey Forms ] Fixed form labels in the editor turning white and invisible when a dark palette such as BG Black is selected
-* [ Design Bug Fix ][ Snow Monkey Forms ] Fixed form input fields on the front end showing white text on a white background when a dark palette such as BG Black is selected
+* [ Design Bug Fix ][ Snow Monkey Forms ] Fixed form labels and input fields becoming invisible ( white text on white background ) in both the editor and front end when a dark palette such as BG Black is selected
 
 = 1.41.2 =
 [ Design Bug Fix ] Removed the text-light class from post titles in block patterns so the font weight set in the editor is no longer overridden by its font-weight: lighter !important

--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 == Changelog ==
 
 * [ Design Bug Fix ][ Snow Monkey Forms ] Fixed form labels in the editor turning white and invisible when a dark palette such as BG Black is selected
+* [ Design Bug Fix ][ Snow Monkey Forms ] Fixed form input fields on the front end showing white text on a white background when a dark palette such as BG Black is selected
 
 = 1.41.2 =
 [ Design Bug Fix ] Removed the text-light class from post titles in block patterns so the font weight set in the editor is no longer overridden by its font-weight: lighter !important


### PR DESCRIPTION
close #463

## 概要

BG Black 等のダークパレット選択時に Snow Monkey Forms のフォーム表示が白文字になって見えなくなる問題を2箇所修正。

1. **エディタ**：フォームアイテムのラベル・説明文が白文字になって見えない
2. **フロントエンド**：テキスト入力・テキストエリア・セレクトボックスが白文字になって見えない

### 原因

`theme.json` の `styles.color.text: var(--wp--preset--color--text-normal)` により、BG Black パレット時はエディタ iframe の body および各入力要素に `color: #fff` が適用される。一方、Snow Monkey Forms はフォームコントロールの背景色を `background-color: var(--_color-white)` で白に固定しているため、白文字×白背景になって不可視になる。

### 対応

**エディタ修正** (`smf-editor.scss/css`)：
`.snow-monkey-forms-setting-panel` および `.smf-item__label` / `.smf-item .smf-item__description` に `color: initial` を設定し、body からの white color 継承を切る。`revert` ではなく `initial` を使う理由：`div` 等に対して UA スタイルシートに `color` ルールがないため `revert` は `inherit` と同じになり修正にならないため。

**フロントエンド修正** (`smf.scss/css`)：
`.smf-text-control__control` / `.smf-textarea-control__control` / `.smf-select-control__control` に `color: var(--_color-text, #333)` を設定。SMF 自身が白背景向けに定義している `--_color-text: #333` を使用。

### 変更ファイル

- `plugin-support/snow-monkey-forms/_scss/smf-editor.scss`（新規）
- `plugin-support/snow-monkey-forms/css/smf-editor.css`（新規・コンパイル済み）
- `plugin-support/snow-monkey-forms/_scss/smf.scss`（変更）
- `plugin-support/snow-monkey-forms/css/smf.css`（変更・コンパイル済み）
- `functions.php` — SMF 有効時のみ `add_editor_style` で読み込み

### メンテナンスメモ

この修正は Snow Monkey Forms が `background-color: var(--_color-white)` で白背景をハードコードしていることを前提としています。

仮に SMF 側の背景色設計が変更される場合はデザイン全体の見直しを伴う大きな変更になると思われるため、現実的にはほぼ起きないと想定しています。念のため記録として残しておきますが、SMF のメジャーアップデート等でフォームコントロールの背景色が変わった際には `smf.scss` / `smf-editor.scss` の `color` 上書きが不要になる可能性があります。

---

## 確認手順

### 前提条件

- Snow Monkey Forms プラグインを有効化済み
- 外観 > エディタ > スタイル > パレットで **BG Black** を選択して保存済み

### Before（修正前の再現手順）

1. Snow Monkey Forms で作成した「お問合せ」投稿の編集画面を開く
2. フォームアイテムブロックのラベルを確認する
   → ✗ ラベルが白文字になって背景色（白）に溶け込み、視認できない
3. フロントエンドでお問合せフォームページを表示する
4. テキスト入力欄・テキストエリア・セレクトボックスを確認する
   → ✗ 入力フィールドが白背景に白文字で見えない

### After（修正後の確認手順）

1. Snow Monkey Forms で作成した「お問合せ」投稿の編集画面を開く
2. フォームアイテムブロックのラベルを確認する
   → ✓ ラベルが正常な文字色で表示され、読める
3. フロントエンドでお問合せフォームページを表示する
4. テキスト入力欄・テキストエリア・セレクトボックスを確認する
   → ✓ 入力フィールドの文字色が暗色（`#333`）になり、白背景上で読める

### デグレ確認

1. BG Black 以外のパレット（デフォルト等）でも同様に確認する
   → ✓ 表示が崩れていない
2. Snow Monkey Forms が無効な環境でも編集画面が正常に動作することを確認する
   → ✓ `smf-editor.css` は `class_exists` ガードにより読み込まれない

## スクリーンショット

### Before
（修正前：BG Black パレット時にラベルや入力フィールドが見えない状態）
#### ▼編集画面
<img width="1229" height="840" alt="スクリーンショット 2026-06-25 11 01 28" src="https://github.com/user-attachments/assets/3a9dbd9f-0606-4f36-899c-02ca2bbc3d38" />

#### ▼フロント
<img width="1175" height="803" alt="スクリーンショット 2026-06-25 11 01 55" src="https://github.com/user-attachments/assets/74adc371-d471-408d-974d-7b9557c5087f" />

### After
（修正後：ラベルおよび入力フィールドが正常に表示されている状態）
#### ▼編集画面
<img width="1232" height="831" alt="スクリーンショット 2026-06-25 10 59 03" src="https://github.com/user-attachments/assets/3762a87f-211b-4b4d-98c5-b25545b62c0a" />

#### ▼フロント
<img width="1207" height="792" alt="スクリーンショット 2026-06-25 10 58 24" src="https://github.com/user-attachments/assets/61a14855-a94b-4a16-8445-72f782233faf" />
