### PR TITLE
[ デザイン不具合修正 ][ ナビゲーションブロック ] 横メニュー共通スタイルが初期配置時に適用されない不具合を修正

### DIFF
--- a/assets/_scss/_navigation.scss
+++ b/assets/_scss/_navigation.scss
@@ -299,7 +299,11 @@ Overlay : allways ***********************
 /****************************************************** 
  *  Horizontal Navigation common styles
  */
- .wp-block-navigation:is(.is-horizontal) {
+ // .is-horizontal is not applied on initial placement; it only takes effect after
+ // switching to vertical and back to horizontal, so we target with :not(.is-vertical).
+ // .is-horizontal は初期配置の時はつかず、一度 vertical にして horizontal 指定しないと
+ // 効かないため、:not(.is-vertical) で指定している。
+ .wp-block-navigation:where(:not(.is-vertical)) {
 	// 横メニューのサブメニューでのみ文字サイズが小さくなるように
 	&:where(:not(:has(.has-modal-open))) {
 		:where(.wp-block-navigation__submenu-container) {

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Bug Fix ][ Navigation Block ] Fixed an issue where horizontal navigation styles ( submenu font size, item padding, and submenu background ) were not applied on initial placement because the .is-horizontal class is absent by default
+
 = 1.41.2 =
 [ Design Bug Fix ] Removed the text-light class from post titles in block patterns so the font weight set in the editor is no longer overridden by its font-weight: lighter !important
 


### PR DESCRIPTION
## 概要

横メニュー（横並びのナビゲーションブロック）の共通スタイルが、ブロック配置直後（初期状態）には適用されない不具合を修正しました。

WordPress ナビゲーションブロックの `.is-horizontal` クラスは初期配置時には付与されず、一度 vertical に切り替えてから再度 horizontal を指定しないと付かない仕様です。そのため `.wp-block-navigation:is(.is-horizontal)` で指定していた横メニュー共通スタイル（サブメニューの文字サイズ・項目の左 padding・サブメニュー背景色など）が初期配置の横メニューに効かない状態でした。

セレクタを `:where(:not(.is-vertical))` に変更し、vertical 以外（＝横メニュー）に対して適用されるようにしました。あわせて `:where()` で包むことで詳細度を上げないようにしています（`css.md` のルール準拠）。

## 変更内容

- `assets/_scss/_navigation.scss`: 横メニュー共通スタイルのセレクタを `:is(.is-horizontal)` から `:where(:not(.is-vertical))` に変更し、理由をコメントで明記
- `readme.txt`: changelog に追記

## 確認手順

### 前提
- フルサイト編集対応テーマ X-T9 を有効化したサイト

### Before（修正前の再現）
1. 投稿または固定ページ、もしくはテンプレートにナビゲーションブロックを新規追加する
2. メニュー項目にサブメニュー（子項目）を持つ項目を追加する
3. ナビゲーションブロックの向きは初期状態（横並び）のまま、設定で vertical へ切り替えないでおく
4. フロント／エディタでサブメニューを開く
   → サブメニューの文字サイズが x-small にならず、項目の左 padding やサブメニュー背景色も適用されていない

### After（修正後の確認）
1. 上記と同じ手順で、初期状態（横並び）のナビゲーションブロックを配置する
2. フロント／エディタでサブメニューを開く
   → サブメニューの文字サイズが x-small になり、項目の左 padding・サブメニュー背景色が適用される
3. 設定でナビゲーションを vertical（縦並び）に切り替える
   → 横メニュー共通スタイルが縦メニューには適用されないこと（従来どおりの縦メニュー表示）を確認

### デグレ確認
- 一度 vertical → horizontal と切り替えて `.is-horizontal` が付いた状態の横メニューでも、従来どおり同じスタイルが適用されること
- オーバーレイ（モバイルメニュー）内のナビゲーションの表示が崩れていないこと

## スクリーンショット

> 表示に関わる変更のため、Before / After のスクリーンショットを添付してください（初期配置の横メニューでサブメニューを開いた状態の比較）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ナビゲーションブロックで、初期表示時に水平メニューの見た目が正しく適用されない問題を修正しました。
  * サブメニューの文字サイズ、項目の余白、背景スタイルが、縦横の切り替え後だけでなく初期状態でも適切に反映されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->