### PR TITLE
[ デザイン不具合修正 ][ ナビゲーションブロック ] active-border-bottom 使用時にホバーでサブメニューのドロップダウンアイコンが下にずれる不具合を修正

### DIFF
--- a/assets/_scss/_navigation_additional-class.scss
+++ b/assets/_scss/_navigation_additional-class.scss
@@ -56,7 +56,18 @@
 	// Overlay : off（ It is now positioned directly below .wp-block-navigation. ）
 	& > :where( .wp-block-navigation__container, .wp-block-page-list ) {
 			&>.wp-block-navigation-item {
-				&>:where(:is( a, .wp-block-navigation-submenu__toggle )) {
+				// Add vertical padding to the text. ////////////////////
+				// When the submenu opens on click, the whole item is wrapped by .wp-block-navigation-submenu__toggle,
+				// but on hover the submenu icon also gets .wp-block-navigation-submenu__toggle and the icon drops down,
+				// so exclude it with :not(.wp-block-navigation__submenu-icon).
+				// 文字の上下に余白を追加する。
+				// サブメニューの表示がクリックの場合は全体を .wp-block-navigation-submenu__toggle が囲うが、
+				// ホバーの場合はアイコン部分にも .wp-block-navigation-submenu__toggle がついてアイコンの位置が
+				// 下になってしまうため、:not(.wp-block-navigation__submenu-icon) で除外する。
+				&>:where(:is( 
+					a, 
+					.wp-block-navigation-submenu__toggle:where(:not(.wp-block-navigation__submenu-icon))
+				)) {
 					padding-top: 1em;
 					padding-bottom: 1em;
 				}

--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 == Changelog ==
 
 [ Design Bug Fix ][ Navigation Block ] Fixed an issue where horizontal navigation styles ( submenu font size, item padding, and submenu background ) were not applied on initial placement because the .is-horizontal class is absent by default
+[ Design Bug Fix ][ Navigation Block ] Fixed an issue where the submenu dropdown icon dropped below the menu text on hover when using the active-border-bottom additional class style
 
 = 1.41.2 =
 [ Design Bug Fix ] Removed the text-light class from post titles in block patterns so the font weight set in the editor is no longer overridden by its font-weight: lighter !important


### PR DESCRIPTION
## 概要

`nav--active-border-bottom` 系の追加クラスを付けたナビゲーションブロックで、サブメニューの表示を**ホバー**にした場合に、サブメニューのドロップダウンアイコンが文字より下にずれて表示される不具合を修正しました。

メニュー項目には文字の上下に余白を出すため `padding-top / padding-bottom: 1em` を付けています。サブメニューが「クリックで開く」の場合は項目全体を `.wp-block-navigation-submenu__toggle` が囲うのに対し、「ホバーで開く」の場合はアイコン部分（`.wp-block-navigation__submenu-icon`）にも `.wp-block-navigation-submenu__toggle` が付与されるため、この上下 padding がアイコンにも効いてアイコンが下にずれていました。

セレクタを `.wp-block-navigation-submenu__toggle:where(:not(.wp-block-navigation__submenu-icon))` に変更し、アイコン要素を padding 適用対象から除外しました。

## 変更内容

- `assets/_scss/_navigation_additional-class.scss`: 上下 padding の対象から submenu アイコンを除外し、理由をコメントで明記

## 確認手順

### 前提
- フルサイト編集対応テーマ X-T9 を有効化したサイト
- サブメニュー（子項目）を持つナビゲーションブロックを用意

### Before（修正前の再現）
1. ナビゲーションブロックに `nav--active-border-bottom` の追加 CSS クラスを付与する
2. ブロック設定でサブメニューの表示を「マウスオーバーで表示」（ホバー）にする
3. サブメニューを持つ親項目を表示する
   → 親項目のドロップダウンアイコン（▼）が文字のベースラインより下にずれて表示される

### After（修正後の確認）
1. 上記と同じ設定（`nav--active-border-bottom` + ホバー表示）で表示する
   → ドロップダウンアイコンが文字と同じ高さに揃って表示される
2. サブメニューの表示を「クリックで表示」に切り替える
   → 従来どおりアイコン・文字の位置が崩れていないことを確認

### デグレ確認
- サブメニューを持たない通常項目の上下余白（`padding: 1em`）が従来どおり保たれていること
- アクティブ時の下線（active-border-bottom）の表示位置・アニメーションが変わっていないこと

## スクリーンショット

> 表示に関わる変更のため、ホバー表示時のドロップダウンアイコン位置の Before / After スクリーンショットを添付してください。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ナビゲーションブロックで、アクティブな下線スタイル使用時にサブメニューのアイコンがホバーでずれて表示される問題を修正しました。
  * クリック時とホバー時の挙動の違いに対応し、メニューラベルの位置が不意に変わらないよう改善しました。

* **Documentation**
  * 変更内容を更新し、サブメニューのドロップダウンアイコンに関する修正点を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->