### PR TITLE
[ 不具合修正 ] PHP 8.0以降で未登録の投稿タイプアーカイブへアクセスした際にPHP警告が記録される不具合を修正

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -121,8 +121,10 @@ function xt9_get_the_archive_title() {
 		global $wp_query;
 		// get post type.
 		if ( ! empty( $wp_query->query_vars['post_type'] ) ) {
-			$post_type = $wp_query->query_vars['post_type'];
-			$title     = get_post_type_object( $post_type )->labels->name;
+			$post_type     = $wp_query->query_vars['post_type'];
+			// get_post_type_object() は未登録の投稿タイプに対して null を返すため、null ガードを入れる.
+			$post_type_obj = get_post_type_object( $post_type );
+			$title         = $post_type_obj ? $post_type_obj->labels->name : __( 'Archives', 'x-t9' );
 		} else {
 			$title = __( 'Archives', 'x-t9' );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
-* [ 不具合修正 ] PHP 8.0 以降で未登録の投稿タイプアーカイブへアクセスした際に PHP 警告が記録される不具合を修正
+[ Bug Fix ] Fixed PHP warning recorded when accessing an archive of an unregistered post type on PHP 8.0 or later
 
 = 1.41.6 =
 [ Other ] Change screenshot file

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+* [ 不具合修正 ] PHP 8.0 以降で未登録の投稿タイプアーカイブへアクセスした際に PHP 警告が記録される不具合を修正
+
 = 1.41.6 =
 [ Other ] Change screenshot file
 

--- a/tests/test_xt9_get_the_archive_title.php
+++ b/tests/test_xt9_get_the_archive_title.php
@@ -202,4 +202,42 @@ class Test_Xt9_Get_The_Archive_Title extends WP_UnitTestCase {
 			$this->assertEquals( $case['expected'], $actual, $case['test_condition_name'] );
 		}
 	}
+
+	/**
+	 * 未登録の投稿タイプが設定された場合に E_WARNING が発生しないことをテストします。
+	 * PHP 8.0 以降では get_post_type_object() が null を返す際に ->labels->name アクセスで
+	 * 警告が発生するため、null ガードが正しく機能しているかを検証します。
+	 */
+	public function test_xt9_get_the_archive_title_with_unregistered_post_type_does_not_trigger_warning() {
+		// 未登録の post_type を設定.
+		global $wp_query;
+		$original_post_type = $wp_query->query_vars['post_type'] ?? '';
+		$wp_query->query_vars['post_type'] = 'unregistered_post_type_xyz';
+
+		// E_WARNING 発生を検知するためのフラグと error handler を設定.
+		$warning_occurred = false;
+		set_error_handler(
+			function( $errno ) use ( &$warning_occurred ) {
+				if ( E_WARNING === $errno ) {
+					$warning_occurred = true;
+				}
+				return true;
+			}
+		);
+
+		$result = null;
+		try {
+			// テスト関数を実行.
+			$result = xt9_get_the_archive_title();
+		} finally {
+			// error handler とクエリ変数を確実に復元.
+			restore_error_handler();
+			$wp_query->query_vars['post_type'] = $original_post_type;
+		}
+
+		// 未登録の post_type で E_WARNING が発生しないことを確認.
+		$this->assertFalse( $warning_occurred, '未登録の post_type で E_WARNING が発生した' );
+		// フォールバック値が 'Archives' であることを確認.
+		$this->assertEquals( __( 'Archives', 'x-t9' ), $result, '未登録の post_type のフォールバックが Archives でない' );
+	}
 }

--- a/tests/test_xt9_get_the_archive_title.php
+++ b/tests/test_xt9_get_the_archive_title.php
@@ -211,7 +211,8 @@ class Test_Xt9_Get_The_Archive_Title extends WP_UnitTestCase {
 	public function test_xt9_get_the_archive_title_with_unregistered_post_type_does_not_trigger_warning() {
 		// 未登録の post_type を設定.
 		global $wp_query;
-		$original_post_type = $wp_query->query_vars['post_type'] ?? '';
+		$post_type_key_existed = array_key_exists( 'post_type', $wp_query->query_vars );
+		$original_post_type    = $post_type_key_existed ? $wp_query->query_vars['post_type'] : null;
 		$wp_query->query_vars['post_type'] = 'unregistered_post_type_xyz';
 
 		// E_WARNING 発生を検知するためのフラグと error handler を設定.
@@ -232,7 +233,11 @@ class Test_Xt9_Get_The_Archive_Title extends WP_UnitTestCase {
 		} finally {
 			// error handler とクエリ変数を確実に復元.
 			restore_error_handler();
-			$wp_query->query_vars['post_type'] = $original_post_type;
+			if ( $post_type_key_existed ) {
+				$wp_query->query_vars['post_type'] = $original_post_type;
+			} else {
+				unset( $wp_query->query_vars['post_type'] );
+			}
 		}
 
 		// 未登録の post_type で E_WARNING が発生しないことを確認.


### PR DESCRIPTION
## 関連Issue

- 関連Issue: vektor-inc/multi-repo-tasks#23

## 変更の目的・理由

PHP 8.0以降、`null` に対してプロパティアクセスすると `E_WARNING` が発生します。`xt9_get_the_archive_title()` 関数内で `get_post_type_object( $post_type )->labels->name` を直接参照している箇所があり、プラグイン無効化後の旧URLなど未登録の投稿タイプにアクセスした際に `PHP 8.0 Warning: Attempt to read property "labels" on null` がエラーログに記録されます。

## 実装内容

### 主な変更点

- [x] バグ修正

### 修正内容

`functions.php` の `xt9_get_the_archive_title()` 関数内で `get_post_type_object()` の戻り値を変数に受け、null チェック後にプロパティアクセスするよう修正。

```php
// 修正前
$title = get_post_type_object( $post_type )->labels->name;

// 修正後
$post_type_obj = get_post_type_object( $post_type );
$title         = $post_type_obj ? $post_type_obj->labels->name : __( 'Archives', 'x-t9' );
```

フォールバック値は既存の `else` 節（`$post_type` が未設定の場合）と同じ `__( 'Archives', 'x-t9' )` に統一しています。

## テスト（確認手順）

### Before（再現手順）

1. PHP 8.0以降の環境でWordPressを起動し、`error_reporting( E_ALL )` を有効化する
2. 存在しない投稿タイプのアーカイブURL（例: `<サイトURL>/?post_type=unregistered_type`）にアクセスする
3. → エラーログに `Warning: Attempt to read property "labels" on null` が記録されることを確認

### After（修正確認）

1. 同様の環境で上記手順を実施する
2. → エラーログに警告が記録されず、アーカイブタイトルに "Archives" が表示されることを確認

### デグレ確認

1. 通常の投稿タイプアーカイブ（例: `?post_type=post`）にアクセスする
2. → アーカイブタイトルに投稿タイプ名が正常に表示されることを確認

### PHPUnit

```bash
npm run phpunit
```

→ `tests/test_xt9_get_the_archive_title.php` を含む全テストがパスすること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 未登録の投稿タイプのアーカイブ表示で、PHP warning が発生しないように修正しました。
  * 該当する場合は、アーカイブ名の代わりに「Archives」を表示するようになりました。

* **Tests**
  * 未登録の投稿タイプでも warning が出ないことと、適切なフォールバック表示になることを確認するテストを追加しました。

* **Documentation**
  * 更新履歴に今回の不具合修正を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->