### PR TITLE
[ 不具合修正 ] 追加CSS使用時(WP7.0+)に見出しのフルードタイポグラフィが固定値で上書きされるWordPressコア側の不具合を回避

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -85,6 +85,8 @@ require get_template_directory() . '/inc/block-styles.php';
 if ( version_compare( get_bloginfo( 'version' ), '6.6', '>=' ) ) {
 	require get_template_directory() . '/inc/typography-defaults.php';
 }
+// Workaround for a WordPress core style print-order bug affecting fluid typography (see file for details).
+require get_template_directory() . '/inc/global-styles-print-order-fix.php';
 // Load TGM.
 require get_template_directory() . '/inc/tgm-plugin-activation/tgm-config.php';
 

--- a/inc/global-styles-print-order-fix.php
+++ b/inc/global-styles-print-order-fix.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Workaround for a WordPress core style print-order bug (WP 7.0 / 7.0.1).
+ *
+ * WordPress 7.0 で追加された「ブロック単位の追加CSS」機能に起因する、
+ * スタイル出力順序の不具合に対する暫定対応。
+ *
+ * @package vektor-inc/x-t9
+ */
+
+/**
+ * Force the `wp-block-library` style handle to always print before `global-styles`.
+ *
+ * WordPress 7.0 introduced the block-level "Additional CSS" feature
+ * ( wp-includes/block-supports/custom-css.php ). When a block on the page uses it,
+ * core registers a new style handle like this:
+ *
+ *     wp_register_style( 'wp-block-custom-css', false, array( 'global-styles' ) );
+ *
+ * Declaring `global-styles` as a dependency of `wp-block-custom-css` causes
+ * WP_Dependencies::do_items() to print `global-styles` earlier than it otherwise
+ * would (right before `wp-block-custom-css`). However `wp-block-library`
+ * ( wp-includes/css/dist/block-library/style.css, which contains WordPress core's
+ * own static fallback values such as `--wp--preset--font-size--huge: 42px;` ) is not
+ * part of that dependency chain, so it keeps its original queue position and ends up
+ * printing AFTER `global-styles` on pages that contain a block with Additional CSS set.
+ * Because both stylesheets declare the same CSS custom properties at the same
+ * specificity ( `:root` ), the one printed last wins — so the theme's fluid
+ * typography `clamp()` values from theme.json get silently overwritten by core's
+ * static fallback values (e.g. a huge heading renders at a fixed 42px instead of the
+ * intended fluid size). This has been reproduced on both WordPress 7.0 and the 7.0.1
+ * beta as of 2026-07 and is a WordPress core bug unrelated to this theme's theme.json.
+ *
+ * WordPress 7.0 で追加された「ブロック単位の追加CSS」機能を使うブロックが
+ * ページ内に存在すると、コアが上記のように `wp-block-custom-css` を
+ * `global-styles` に依存させて登録する。この依存関係により
+ * WP_Dependencies::do_items() が `global-styles` を通常より早いタイミングで
+ * 出力してしまうが、`wp-block-library`
+ * （静的フォールバック値 `--wp--preset--font-size--huge: 42px;` などを含む
+ * wp-includes/css/dist/block-library/style.css）はこの依存グラフに含まれていない
+ * ため、キューの元の位置のまま出力される。結果として追加CSSブロックが存在する
+ * ページだけ `wp-block-library` が `global-styles` より後に出力されてしまい、
+ * 同じ `:root` カスタムプロパティが「後勝ち」でコアの静的値に上書きされ、
+ * テーマの theme.json で定義したフルードタイポグラフィの clamp() 値が効かなくなる
+ * （見出しが固定 42px 等で表示される）。2026年7月時点で WordPress 7.0 の正式版・
+ * 7.0.1 のベータ版いずれでも再現し、x-t9 の theme.json 側の問題ではない
+ * WordPress core 側の不具合である。
+ *
+ * The fix here does not touch print order directly. It simply declares the
+ * dependency that should have existed all along: `wp-block-library` is added as an
+ * explicit dependency of `global-styles`. This way, whenever something pulls
+ * `global-styles` forward in the queue, `wp-block-library` is pulled forward together
+ * with it (and printed first, since it's a dependency), so `wp-block-library` is
+ * always guaranteed to print before `global-styles` — regardless of whether the
+ * "Additional CSS" block support is used on the page, and regardless of whether this
+ * WordPress core bug exists at all in a given WordPress version. This keeps the
+ * function idempotent and harmless if the core bug is fixed upstream in the future.
+ *
+ * 出力順序そのものを直接いじるのではなく、本来あるべき依存関係
+ * 「`wp-block-library` は `global-styles` より先に出力される」を明示的に
+ * 追加するだけの対応とする。これにより、何らかの理由で `global-styles` が
+ * キューの先頭側に引き上げられた場合でも、その依存元である `wp-block-library`
+ * も連動して一緒に引き上げられ、常に `wp-block-library` → `global-styles` の
+ * 順序が保たれる。「追加CSS」ブロックの有無や、将来 WordPress core 側で
+ * この不具合が修正されたかどうかに関わらず安全に動作する（冪等）。
+ *
+ * @return void
+ */
+function xt9_fix_global_styles_print_order() {
+	$wp_styles = wp_styles();
+
+	// Bail if either handle isn't registered yet.
+	// classic themes ( wp_is_block_theme() === false ) or certain edge cases may not
+	// register `global-styles` at all, so this must not assume the handle exists.
+	//
+	// いずれかのハンドルが未登録の場合は何もしない。
+	// クラシックテーマ（ wp_is_block_theme() が false ）等では `global-styles`
+	// ハンドル自体が存在しない可能性があるため、存在確認を必須とする。
+	if ( ! $wp_styles->query( 'global-styles', 'registered' ) || ! $wp_styles->query( 'wp-block-library', 'registered' ) ) {
+		return;
+	}
+
+	$global_styles = $wp_styles->registered['global-styles'];
+
+	// Already declared (e.g. some other code already added it, or this ran twice).
+	// Keeps the function idempotent.
+	//
+	// 既に依存関係が追加されている場合は何もしない（冪等性の確保）。
+	if ( in_array( 'wp-block-library', (array) $global_styles->deps, true ) ) {
+		return;
+	}
+
+	$global_styles->deps[] = 'wp-block-library';
+}
+/*
+ * Hook into `wp_enqueue_scripts` at a priority late enough that both
+ * `wp_common_block_scripts_and_styles()` (registers/enqueues `wp-block-library`) and
+ * `wp_enqueue_global_styles()` (registers `global-styles`) — both hooked at the
+ * default priority 10 — have already run.
+ *
+ * `wp_common_block_scripts_and_styles()`（ `wp-block-library` を登録・enqueue する）
+ * と `wp_enqueue_global_styles()`（ `global-styles` を登録する）は、いずれも
+ * デフォルトの優先度10で `wp_enqueue_scripts` にフックされている。この2つの処理が
+ * 両方完了した後に実行されるよう、それより遅い優先度でフックする。
+ */
+add_action( 'wp_enqueue_scripts', 'xt9_fix_global_styles_print_order', 20 );

--- a/inc/global-styles-print-order-fix.php
+++ b/inc/global-styles-print-order-fix.php
@@ -9,7 +9,8 @@
  */
 
 /**
- * Force the `wp-block-library` style handle to always print before `global-styles`.
+ * Force the `wp-block-library` style handle to always print before `global-styles`,
+ * but only when `wp-block-library` is actually going to be printed anyway.
  *
  * WordPress 7.0 introduced the block-level "Additional CSS" feature
  * ( wp-includes/block-supports/custom-css.php ). When a block on the page uses it,
@@ -64,19 +65,59 @@
  * 順序が保たれる。「追加CSS」ブロックの有無や、将来 WordPress core 側で
  * この不具合が修正されたかどうかに関わらず安全に動作する（冪等）。
  *
+ * IMPORTANT — do not force-load a dequeued `wp-block-library`:
+ * WP_Dependencies::do_items() resolves dependencies via all_deps(), which pulls in
+ * any *registered* dependency of a queued handle regardless of whether that
+ * dependency was itself enqueued. That means merely checking
+ * `query( 'wp-block-library', 'registered' )` is not enough: if some plugin or child
+ * theme intentionally calls `wp_dequeue_style( 'wp-block-library' )` for performance
+ * reasons, simply registering it as a dependency of `global-styles` would defeat that
+ * dequeue and force `wp-block-library` to load again on every page — a regression this
+ * theme must not introduce. To avoid that, this function only adds the dependency when
+ * `wp-block-library` is actually going to be printed anyway, i.e. when
+ * `query( 'wp-block-library', 'enqueued' )` returns true (directly enqueued, or already
+ * pulled in via some other handle's dependency chain).
+ *
+ * 【重要】dequeue 済みの wp-block-library を強制ロードしないための対応:
+ * WP_Dependencies::do_items() は all_deps() で依存関係を解決する際、
+ * キューに入っているハンドルの依存先が「登録されているだけ」であれば、
+ * それが実際に enqueue されたかどうかに関わらず出力対象に引き込んでしまう。
+ * そのため `query( 'wp-block-library', 'registered' )` だけでは不十分で、
+ * パフォーマンス目的で `wp_dequeue_style( 'wp-block-library' )` を呼んでいる
+ * プラグイン・子テーマが存在した場合、その dequeue を無効化して
+ * wp-block-library を強制的に再ロードしてしまう副作用が起きる。
+ * これを避けるため、`wp-block-library` が「どのみち出力される」状態
+ * （ `query( 'wp-block-library', 'enqueued' )` が true。直接 enqueue 済み、
+ * または他のハンドルの依存関係経由で既に読み込まれる状態を含む）の場合のみ
+ * 依存関係を追加する。
+ *
  * @return void
  */
 function xt9_fix_global_styles_print_order() {
 	$wp_styles = wp_styles();
 
-	// Bail if either handle isn't registered yet.
+	// Bail if `global-styles` isn't registered.
 	// classic themes ( wp_is_block_theme() === false ) or certain edge cases may not
 	// register `global-styles` at all, so this must not assume the handle exists.
 	//
-	// いずれかのハンドルが未登録の場合は何もしない。
+	// global-styles が未登録の場合は何もしない。
 	// クラシックテーマ（ wp_is_block_theme() が false ）等では `global-styles`
 	// ハンドル自体が存在しない可能性があるため、存在確認を必須とする。
-	if ( ! $wp_styles->query( 'global-styles', 'registered' ) || ! $wp_styles->query( 'wp-block-library', 'registered' ) ) {
+	if ( ! $wp_styles->query( 'global-styles', 'registered' ) ) {
+		return;
+	}
+
+	// Bail unless wp-block-library is registered AND actually going to be printed
+	// (directly enqueued, or pulled in via another handle's dependency chain).
+	// If it has been explicitly dequeued (e.g. by a performance-focused plugin or
+	// child theme) and nothing else needs it, leave it dequeued — do not force it
+	// back in just to fix the print order of a style that would not be printed anyway.
+	//
+	// wp-block-library が登録済みかつ「どのみち出力される」状態
+	// （直接 enqueue 済み、または他ハンドル経由で読み込まれる）でない場合は何もしない。
+	// 明示的に dequeue されていて他に読み込む理由もない場合は、その dequeue を
+	// 尊重し、出力順序の都合だけで強制的に復活させない。
+	if ( ! $wp_styles->query( 'wp-block-library', 'registered' ) || ! $wp_styles->query( 'wp-block-library', 'enqueued' ) ) {
 		return;
 	}
 
@@ -93,14 +134,24 @@ function xt9_fix_global_styles_print_order() {
 	$global_styles->deps[] = 'wp-block-library';
 }
 /*
- * Hook into `wp_enqueue_scripts` at a priority late enough that both
- * `wp_common_block_scripts_and_styles()` (registers/enqueues `wp-block-library`) and
- * `wp_enqueue_global_styles()` (registers `global-styles`) — both hooked at the
- * default priority 10 — have already run.
+ * Hook as late as possible before styles are actually printed, so that the
+ * `enqueued` check above reflects the final queue state — including any
+ * `wp_dequeue_style( 'wp-block-library' )` call made by another plugin or child
+ * theme at any priority on `wp_enqueue_scripts`.
  *
- * `wp_common_block_scripts_and_styles()`（ `wp-block-library` を登録・enqueue する）
- * と `wp_enqueue_global_styles()`（ `global-styles` を登録する）は、いずれも
- * デフォルトの優先度10で `wp_enqueue_scripts` にフックされている。この2つの処理が
- * 両方完了した後に実行されるよう、それより遅い優先度でフックする。
+ * `wp_enqueue_scripts` itself fires on `wp_head` at priority 1, and core prints
+ * styles via `wp_print_styles()` on `wp_head` at priority 8. Hooking at `wp_head`
+ * priority 7 runs after the entire `wp_enqueue_scripts` action (and therefore after
+ * any dequeue calls within it) has completed, but still before printing.
+ *
+ * スタイルが実際に出力される直前まで判定を遅らせることで、上記の `enqueued`
+ * チェックが最終的なキュー状態（他のプラグイン・子テーマが `wp_enqueue_scripts`
+ * のどの優先度で `wp_dequeue_style( 'wp-block-library' )` を呼んでいても）を
+ * 正しく反映できるようにする。
+ *
+ * `wp_enqueue_scripts` 自体は `wp_head` の優先度1で発火し、コアはスタイルを
+ * `wp_head` の優先度8で `wp_print_styles()` により出力する。`wp_head` の優先度7で
+ * フックすることで、`wp_enqueue_scripts` アクション全体（その中で行われる
+ * dequeue 処理を含む）が完了した後、かつ出力される前に実行できる。
  */
-add_action( 'wp_enqueue_scripts', 'xt9_fix_global_styles_print_order', 20 );
+add_action( 'wp_head', 'xt9_fix_global_styles_print_order', 7 );

--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 == Changelog ==
 
 [ Bug Fix ] Fixed PHP warning recorded when accessing an archive of an unregistered post type on PHP 8.0 or later
-[ Bug Fix ] Fixed an issue where using a block's Additional CSS (WordPress 7.0+) caused headings using fluid typography to render at WordPress core's static fallback font size instead of the theme's fluid clamp() value
+[ Bug Fix ] Worked around a WordPress core bug (7.0+) that caused headings using fluid typography to render at a fixed font size instead of the theme's fluid clamp() value when a block's Additional CSS was used
 
 = 1.41.6 =
 [ Other ] Change screenshot file

--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 == Changelog ==
 
 [ Bug Fix ] Fixed PHP warning recorded when accessing an archive of an unregistered post type on PHP 8.0 or later
+[ Bug Fix ] Fixed an issue where using a block's Additional CSS (WordPress 7.0+) caused headings using fluid typography to render at WordPress core's static fallback font size instead of the theme's fluid clamp() value
 
 = 1.41.6 =
 [ Other ] Change screenshot file

--- a/tests/test_xt9_fix_global_styles_print_order.php
+++ b/tests/test_xt9_fix_global_styles_print_order.php
@@ -35,14 +35,17 @@ class Test_Xt9_Fix_Global_Styles_Print_Order extends WP_UnitTestCase {
 
 	/**
 	 * Test that wp-block-library is added as a dependency of global-styles
-	 * when both handles are registered.
-	 * 両方のハンドルが登録されている場合に、global-styles の依存関係へ
-	 * wp-block-library が追加されることをテストします.
+	 * when both handles are registered and wp-block-library is enqueued.
+	 * 両方のハンドルが登録され、wp-block-library が enqueue されている場合に、
+	 * global-styles の依存関係へ wp-block-library が追加されることをテストします.
 	 */
-	public function test_adds_wp_block_library_as_dependency_of_global_styles() {
-		// Register both style handles the way WordPress core does.
-		// WordPress core と同様の形でハンドルを登録.
+	public function test_adds_wp_block_library_as_dependency_when_enqueued() {
+		// Register both style handles the way WordPress core does, and enqueue
+		// wp-block-library the way wp_common_block_scripts_and_styles() does.
+		// WordPress core と同様の形でハンドルを登録し、
+		// wp_common_block_scripts_and_styles() と同様に wp-block-library を enqueue する.
 		wp_register_style( 'wp-block-library', false );
+		wp_enqueue_style( 'wp-block-library' );
 		wp_register_style( 'global-styles', false );
 
 		xt9_fix_global_styles_print_order();
@@ -52,11 +55,36 @@ class Test_Xt9_Fix_Global_Styles_Print_Order extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that wp-block-library is also recognized as "going to be printed anyway"
+	 * when it is only pulled in indirectly via another enqueued handle's dependency
+	 * chain (WP_Dependencies::query( $handle, 'enqueued' ) resolves this recursively),
+	 * and the dependency is still added in that case.
+	 * wp-block-library が直接 enqueue されておらず、他の enqueue 済みハンドルの
+	 * 依存関係経由で間接的に読み込まれる場合でも
+	 * （ WP_Dependencies::query( $handle, 'enqueued' ) は再帰的に解決するため）
+	 * 「どのみち出力される」と判定され、依存関係が追加されることをテストします.
+	 */
+	public function test_adds_dependency_when_wp_block_library_is_only_indirectly_enqueued() {
+		wp_register_style( 'wp-block-library', false );
+		// Some other handle depends on wp-block-library and is the one actually enqueued.
+		// 他のハンドルが wp-block-library に依存し、そのハンドル自体が enqueue される.
+		wp_register_style( 'some-other-enqueued-style', false, array( 'wp-block-library' ) );
+		wp_enqueue_style( 'some-other-enqueued-style' );
+		wp_register_style( 'global-styles', false );
+
+		xt9_fix_global_styles_print_order();
+
+		$global_styles = wp_styles()->registered['global-styles'];
+		$this->assertContains( 'wp-block-library', $global_styles->deps, '間接的に読み込まれる wp-block-library が依存関係に追加されていない' );
+	}
+
+	/**
 	 * Test that running the function twice does not add the dependency twice (idempotency).
 	 * 2回実行しても依存関係が重複追加されないことをテストします（冪等性）.
 	 */
 	public function test_is_idempotent_when_run_twice() {
 		wp_register_style( 'wp-block-library', false );
+		wp_enqueue_style( 'wp-block-library' );
 		wp_register_style( 'global-styles', false );
 
 		xt9_fix_global_styles_print_order();
@@ -82,6 +110,7 @@ class Test_Xt9_Fix_Global_Styles_Print_Order extends WP_UnitTestCase {
 	 */
 	public function test_does_nothing_when_global_styles_is_not_registered() {
 		wp_register_style( 'wp-block-library', false );
+		wp_enqueue_style( 'wp-block-library' );
 		// global-styles is intentionally left unregistered.
 		// global-styles は意図的に未登録の状態にする.
 
@@ -91,7 +120,7 @@ class Test_Xt9_Fix_Global_Styles_Print_Order extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that nothing happens when wp-block-library is not registered.
+	 * Test that nothing happens when wp-block-library is not registered at all.
 	 * wp-block-library が未登録の場合に、global-styles の依存関係が
 	 * 変更されないことをテストします.
 	 */
@@ -104,5 +133,47 @@ class Test_Xt9_Fix_Global_Styles_Print_Order extends WP_UnitTestCase {
 
 		$global_styles = wp_styles()->registered['global-styles'];
 		$this->assertNotContains( 'wp-block-library', $global_styles->deps, '未登録のはずの wp-block-library が依存関係に追加されてしまっている' );
+	}
+
+	/**
+	 * Regression test for a side effect flagged in code review: if a plugin or child
+	 * theme intentionally calls wp_dequeue_style( 'wp-block-library' ) for performance
+	 * reasons, this function must not add it as a dependency of global-styles, because
+	 * WP_Dependencies::do_items() would then force wp-block-library to print anyway
+	 * (dependencies are pulled in as long as they are *registered*, regardless of
+	 * whether they were themselves enqueued). Doing so would silently defeat the
+	 * dequeue and reload wp-block-library on every page.
+	 * コードレビューで指摘された副作用の再現防止テストです。パフォーマンス目的で
+	 * プラグインや子テーマが wp_dequeue_style( 'wp-block-library' ) を呼んでいる場合、
+	 * この関数はそれを wp-block-library に依存関係を追加してはいけません。
+	 * WP_Dependencies::do_items() は「登録されているだけ」の依存を出力対象へ
+	 * 引き込んでしまうため、依存関係を追加すると dequeue が無効化され、
+	 * 全ページで wp-block-library が強制的に再ロードされてしまいます。
+	 */
+	public function test_does_not_force_load_wp_block_library_when_dequeued() {
+		wp_register_style( 'wp-block-library', false );
+		wp_enqueue_style( 'wp-block-library' );
+		wp_register_style( 'global-styles', false );
+		wp_enqueue_style( 'global-styles' );
+
+		// Simulate a third-party plugin/child theme dequeuing wp-block-library for
+		// performance reasons, at some priority after our own hook would normally run.
+		// パフォーマンス目的でサードパーティのプラグイン・子テーマが
+		// wp-block-library を dequeue するケースを再現する.
+		wp_dequeue_style( 'wp-block-library' );
+
+		xt9_fix_global_styles_print_order();
+
+		$global_styles = wp_styles()->registered['global-styles'];
+		$this->assertNotContains(
+			'wp-block-library',
+			$global_styles->deps,
+			'dequeue 済みの wp-block-library が global-styles の依存関係に追加され、強制ロードされてしまっている'
+		);
+		$this->assertNotContains(
+			'wp-block-library',
+			wp_styles()->queue,
+			'dequeue 済みの wp-block-library がキューに復活してしまっている'
+		);
 	}
 }

--- a/tests/test_xt9_fix_global_styles_print_order.php
+++ b/tests/test_xt9_fix_global_styles_print_order.php
@@ -34,146 +34,196 @@ class Test_Xt9_Fix_Global_Styles_Print_Order extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that wp-block-library is added as a dependency of global-styles
-	 * when both handles are registered and wp-block-library is enqueued.
-	 * 両方のハンドルが登録され、wp-block-library が enqueue されている場合に、
-	 * global-styles の依存関係へ wp-block-library が追加されることをテストします.
+	 * Test xt9_fix_global_styles_print_order() across the full set of registration /
+	 * enqueue / dequeue conditions it needs to handle.
+	 *
+	 * Each case's starting state is expressed as a data-driven `setup` list of
+	 * register / enqueue / dequeue actions (rather than one bespoke test method per
+	 * condition), per testing/phpunit.md's "条件と期待値をセットで配列に入れてループ
+	 * しながら処理する" convention. Because more than one aspect of the resulting
+	 * state can matter for a given case (global-styles registration state, its deps,
+	 * and the final print queue), each case declares only the `expected_*` keys that
+	 * are relevant to it; keys that are omitted are simply not asserted.
+	 *
+	 * xt9_fix_global_styles_print_order() が扱う登録・enqueue・dequeue の
+	 * 各条件を網羅的にテストします。
+	 *
+	 * 条件ごとに個別のテストメソッドを用意するのではなく、各ケースの開始状態を
+	 * register / enqueue / dequeue の操作列（`setup`）としてデータ化し、
+	 * testing/phpunit.md の「条件と期待値をセットで配列に入れてループしながら
+	 * 処理する」規約に沿ってループ実行します。ケースによって確認すべき観点
+	 * （ global-styles の登録状態・その deps・最終的な print queue ）が異なるため、
+	 * 各ケースはそのケースに関係する `expected_*` キーのみを宣言し、
+	 * 宣言されていないキーは検証をスキップします.
 	 */
-	public function test_adds_wp_block_library_as_dependency_when_enqueued() {
-		// Register both style handles the way WordPress core does, and enqueue
-		// wp-block-library the way wp_common_block_scripts_and_styles() does.
-		// WordPress core と同様の形でハンドルを登録し、
-		// wp_common_block_scripts_and_styles() と同様に wp-block-library を enqueue する.
-		wp_register_style( 'wp-block-library', false );
-		wp_enqueue_style( 'wp-block-library' );
-		wp_register_style( 'global-styles', false );
+	public function test_xt9_fix_global_styles_print_order() {
+		global $wp_styles;
 
-		xt9_fix_global_styles_print_order();
+		$test_cases = array(
+			array(
+				'test_condition_name'    => 'wp-block-library が直接 enqueue されている場合 => global-styles の依存関係に追加される',
+				'setup'                  => array(
+					array( 'action' => 'register', 'handle' => 'wp-block-library' ),
+					array( 'action' => 'enqueue', 'handle' => 'wp-block-library' ),
+					array( 'action' => 'register', 'handle' => 'global-styles' ),
+				),
+				'run_twice'              => false,
+				'expected_deps_contains' => true,
+			),
+			array(
+				'test_condition_name'    => '他の enqueue 済みハンドル経由で wp-block-library が間接的に読み込まれる場合 => global-styles の依存関係に追加される',
+				'setup'                  => array(
+					array( 'action' => 'register', 'handle' => 'wp-block-library' ),
+					// Some other handle depends on wp-block-library and is the one actually enqueued.
+					// 他のハンドルが wp-block-library に依存し、そのハンドル自体が enqueue される.
+					array(
+						'action' => 'register',
+						'handle' => 'some-other-enqueued-style',
+						'deps'   => array( 'wp-block-library' ),
+					),
+					array( 'action' => 'enqueue', 'handle' => 'some-other-enqueued-style' ),
+					array( 'action' => 'register', 'handle' => 'global-styles' ),
+				),
+				'run_twice'              => false,
+				'expected_deps_contains' => true,
+			),
+			array(
+				'test_condition_name'    => '2回実行した場合 => 依存関係が重複追加されない（冪等性）',
+				'setup'                  => array(
+					array( 'action' => 'register', 'handle' => 'wp-block-library' ),
+					array( 'action' => 'enqueue', 'handle' => 'wp-block-library' ),
+					array( 'action' => 'register', 'handle' => 'global-styles' ),
+				),
+				'run_twice'              => true,
+				'expected_deps_contains' => true,
+				'expected_deps_count'    => 1,
+			),
+			array(
+				'test_condition_name'                => 'global-styles が未登録の場合（クラシックテーマ等） => エラーも変更も発生せず、global-styles は登録されないまま',
+				'setup'                              => array(
+					array( 'action' => 'register', 'handle' => 'wp-block-library' ),
+					array( 'action' => 'enqueue', 'handle' => 'wp-block-library' ),
+					// global-styles is intentionally left unregistered.
+					// global-styles は意図的に未登録の状態にする.
+				),
+				'run_twice'                          => false,
+				'expected_global_styles_registered'  => false,
+			),
+			array(
+				'test_condition_name'    => 'wp-block-library が未登録の場合 => global-styles の依存関係に追加されない',
+				'setup'                  => array(
+					array( 'action' => 'register', 'handle' => 'global-styles' ),
+					// wp-block-library is intentionally left unregistered.
+					// wp-block-library は意図的に未登録の状態にする.
+				),
+				'run_twice'              => false,
+				'expected_deps_contains' => false,
+			),
+			array(
+				// Regression case for a side effect flagged in code review: if a plugin or
+				// child theme intentionally calls wp_dequeue_style( 'wp-block-library' ) for
+				// performance reasons, this function must not add it as a dependency of
+				// global-styles, because WP_Dependencies::do_items() would then force
+				// wp-block-library to print anyway (dependencies are pulled in as long as
+				// they are *registered*, regardless of whether they were themselves
+				// enqueued). Doing so would silently defeat the dequeue and reload
+				// wp-block-library on every page.
+				// コードレビューで指摘された副作用の再現防止ケース。パフォーマンス目的で
+				// プラグインや子テーマが wp_dequeue_style( 'wp-block-library' ) を
+				// 呼んでいる場合、この関数はそれを wp-block-library への依存関係として
+				// 追加してはいけません。WP_Dependencies::do_items() は「登録されている
+				// だけ」の依存を出力対象へ引き込んでしまうため、依存関係を追加すると
+				// dequeue が無効化され、全ページで wp-block-library が
+				// 強制的に再ロードされてしまいます.
+				'test_condition_name'     => '第三者プラグイン等が wp-block-library を dequeue している場合 => 依存関係に追加されず、キューにも復活しない（強制ロードされない）',
+				'setup'                   => array(
+					array( 'action' => 'register', 'handle' => 'wp-block-library' ),
+					array( 'action' => 'enqueue', 'handle' => 'wp-block-library' ),
+					array( 'action' => 'register', 'handle' => 'global-styles' ),
+					array( 'action' => 'enqueue', 'handle' => 'global-styles' ),
+					// Simulate a third-party plugin/child theme dequeuing wp-block-library.
+					// サードパーティのプラグイン・子テーマによる dequeue を再現する.
+					array( 'action' => 'dequeue', 'handle' => 'wp-block-library' ),
+				),
+				'run_twice'               => false,
+				'expected_deps_contains'  => false,
+				'expected_queue_contains' => false,
+			),
+		);
 
-		$global_styles = wp_styles()->registered['global-styles'];
-		$this->assertContains( 'wp-block-library', $global_styles->deps, 'wp-block-library が global-styles の依存関係に追加されていない' );
-	}
+		foreach ( $test_cases as $case ) {
+			// Reset the styles registry before every case so cases don't leak into each other.
+			// ケース間で状態が引き継がれないよう、各ケースの前に styles レジストリをリセットする.
+			$wp_styles = new WP_Styles(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
-	/**
-	 * Test that wp-block-library is also recognized as "going to be printed anyway"
-	 * when it is only pulled in indirectly via another enqueued handle's dependency
-	 * chain (WP_Dependencies::query( $handle, 'enqueued' ) resolves this recursively),
-	 * and the dependency is still added in that case.
-	 * wp-block-library が直接 enqueue されておらず、他の enqueue 済みハンドルの
-	 * 依存関係経由で間接的に読み込まれる場合でも
-	 * （ WP_Dependencies::query( $handle, 'enqueued' ) は再帰的に解決するため）
-	 * 「どのみち出力される」と判定され、依存関係が追加されることをテストします.
-	 */
-	public function test_adds_dependency_when_wp_block_library_is_only_indirectly_enqueued() {
-		wp_register_style( 'wp-block-library', false );
-		// Some other handle depends on wp-block-library and is the one actually enqueued.
-		// 他のハンドルが wp-block-library に依存し、そのハンドル自体が enqueue される.
-		wp_register_style( 'some-other-enqueued-style', false, array( 'wp-block-library' ) );
-		wp_enqueue_style( 'some-other-enqueued-style' );
-		wp_register_style( 'global-styles', false );
-
-		xt9_fix_global_styles_print_order();
-
-		$global_styles = wp_styles()->registered['global-styles'];
-		$this->assertContains( 'wp-block-library', $global_styles->deps, '間接的に読み込まれる wp-block-library が依存関係に追加されていない' );
-	}
-
-	/**
-	 * Test that running the function twice does not add the dependency twice (idempotency).
-	 * 2回実行しても依存関係が重複追加されないことをテストします（冪等性）.
-	 */
-	public function test_is_idempotent_when_run_twice() {
-		wp_register_style( 'wp-block-library', false );
-		wp_enqueue_style( 'wp-block-library' );
-		wp_register_style( 'global-styles', false );
-
-		xt9_fix_global_styles_print_order();
-		xt9_fix_global_styles_print_order();
-
-		$global_styles = wp_styles()->registered['global-styles'];
-		$count         = count(
-			array_filter(
-				$global_styles->deps,
-				static function ( $dep ) {
-					return 'wp-block-library' === $dep;
+			// Replay this case's setup actions (register / enqueue / dequeue) to build its starting state.
+			// このケースの開始状態を register / enqueue / dequeue の操作列で再現する.
+			foreach ( $case['setup'] as $step ) {
+				switch ( $step['action'] ) {
+					case 'register':
+						wp_register_style( $step['handle'], false, $step['deps'] ?? array() );
+						break;
+					case 'enqueue':
+						wp_enqueue_style( $step['handle'] );
+						break;
+					case 'dequeue':
+						wp_dequeue_style( $step['handle'] );
+						break;
 				}
-			)
-		);
-		$this->assertSame( 1, $count, 'wp-block-library が重複して追加されている' );
-	}
+			}
 
-	/**
-	 * Test that nothing happens (no error, no changes) when global-styles is not registered,
-	 * e.g. on a classic theme where this handle may not exist.
-	 * global-styles が未登録の場合（クラシックテーマ等でハンドルが存在しないケース）
-	 * に、エラーも変更も発生しないことをテストします.
-	 */
-	public function test_does_nothing_when_global_styles_is_not_registered() {
-		wp_register_style( 'wp-block-library', false );
-		wp_enqueue_style( 'wp-block-library' );
-		// global-styles is intentionally left unregistered.
-		// global-styles は意図的に未登録の状態にする.
+			// Execute the function under test, twice when this case tests idempotency.
+			// テスト対象の関数を実行する（冪等性を確認するケースでは2回実行する）.
+			xt9_fix_global_styles_print_order();
+			if ( ! empty( $case['run_twice'] ) ) {
+				xt9_fix_global_styles_print_order();
+			}
 
-		xt9_fix_global_styles_print_order();
+			// Only assert global-styles' registration state when this case cares about it.
+			// このケースが対象としている場合のみ global-styles の登録状態を確認する.
+			if ( array_key_exists( 'expected_global_styles_registered', $case ) ) {
+				$this->assertSame(
+					$case['expected_global_styles_registered'],
+					(bool) $wp_styles->query( 'global-styles', 'registered' ),
+					$case['test_condition_name']
+				);
+			}
 
-		$this->assertArrayNotHasKey( 'global-styles', wp_styles()->registered, '未登録のはずの global-styles が登録されてしまっている' );
-	}
+			// Only inspect global-styles->deps when the handle is expected to exist in this case.
+			// global-styles ハンドルが存在するケースに限り deps を確認する.
+			if ( array_key_exists( 'expected_deps_contains', $case ) || array_key_exists( 'expected_deps_count', $case ) ) {
+				$global_styles = $wp_styles->registered['global-styles'];
 
-	/**
-	 * Test that nothing happens when wp-block-library is not registered at all.
-	 * wp-block-library が未登録の場合に、global-styles の依存関係が
-	 * 変更されないことをテストします.
-	 */
-	public function test_does_nothing_when_wp_block_library_is_not_registered() {
-		wp_register_style( 'global-styles', false );
-		// wp-block-library is intentionally left unregistered.
-		// wp-block-library は意図的に未登録の状態にする.
+				if ( array_key_exists( 'expected_deps_contains', $case ) ) {
+					if ( $case['expected_deps_contains'] ) {
+						$this->assertContains( 'wp-block-library', $global_styles->deps, $case['test_condition_name'] );
+					} else {
+						$this->assertNotContains( 'wp-block-library', $global_styles->deps, $case['test_condition_name'] );
+					}
+				}
 
-		xt9_fix_global_styles_print_order();
+				if ( array_key_exists( 'expected_deps_count', $case ) ) {
+					$count = count(
+						array_filter(
+							$global_styles->deps,
+							static function ( $dep ) {
+								return 'wp-block-library' === $dep;
+							}
+						)
+					);
+					$this->assertSame( $case['expected_deps_count'], $count, $case['test_condition_name'] );
+				}
+			}
 
-		$global_styles = wp_styles()->registered['global-styles'];
-		$this->assertNotContains( 'wp-block-library', $global_styles->deps, '未登録のはずの wp-block-library が依存関係に追加されてしまっている' );
-	}
-
-	/**
-	 * Regression test for a side effect flagged in code review: if a plugin or child
-	 * theme intentionally calls wp_dequeue_style( 'wp-block-library' ) for performance
-	 * reasons, this function must not add it as a dependency of global-styles, because
-	 * WP_Dependencies::do_items() would then force wp-block-library to print anyway
-	 * (dependencies are pulled in as long as they are *registered*, regardless of
-	 * whether they were themselves enqueued). Doing so would silently defeat the
-	 * dequeue and reload wp-block-library on every page.
-	 * コードレビューで指摘された副作用の再現防止テストです。パフォーマンス目的で
-	 * プラグインや子テーマが wp_dequeue_style( 'wp-block-library' ) を呼んでいる場合、
-	 * この関数はそれを wp-block-library に依存関係を追加してはいけません。
-	 * WP_Dependencies::do_items() は「登録されているだけ」の依存を出力対象へ
-	 * 引き込んでしまうため、依存関係を追加すると dequeue が無効化され、
-	 * 全ページで wp-block-library が強制的に再ロードされてしまいます。
-	 */
-	public function test_does_not_force_load_wp_block_library_when_dequeued() {
-		wp_register_style( 'wp-block-library', false );
-		wp_enqueue_style( 'wp-block-library' );
-		wp_register_style( 'global-styles', false );
-		wp_enqueue_style( 'global-styles' );
-
-		// Simulate a third-party plugin/child theme dequeuing wp-block-library for
-		// performance reasons, at some priority after our own hook would normally run.
-		// パフォーマンス目的でサードパーティのプラグイン・子テーマが
-		// wp-block-library を dequeue するケースを再現する.
-		wp_dequeue_style( 'wp-block-library' );
-
-		xt9_fix_global_styles_print_order();
-
-		$global_styles = wp_styles()->registered['global-styles'];
-		$this->assertNotContains(
-			'wp-block-library',
-			$global_styles->deps,
-			'dequeue 済みの wp-block-library が global-styles の依存関係に追加され、強制ロードされてしまっている'
-		);
-		$this->assertNotContains(
-			'wp-block-library',
-			wp_styles()->queue,
-			'dequeue 済みの wp-block-library がキューに復活してしまっている'
-		);
+			// Only assert the final print queue when this case cares about it (the dequeue regression case).
+			// このケースが対象としている場合のみ（ dequeue の回帰ケース）最終的な print queue を確認する.
+			if ( array_key_exists( 'expected_queue_contains', $case ) ) {
+				if ( $case['expected_queue_contains'] ) {
+					$this->assertContains( 'wp-block-library', $wp_styles->queue, $case['test_condition_name'] );
+				} else {
+					$this->assertNotContains( 'wp-block-library', $wp_styles->queue, $case['test_condition_name'] );
+				}
+			}
+		}
 	}
 }

--- a/tests/test_xt9_fix_global_styles_print_order.php
+++ b/tests/test_xt9_fix_global_styles_print_order.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Tests for xt9_fix_global_styles_print_order() function.
+ * xt9_fix_global_styles_print_order() 関数のテスト。
+ *
+ * @package x-t9
+ */
+
+/**
+ * Class Test_Xt9_Fix_Global_Styles_Print_Order
+ */
+class Test_Xt9_Fix_Global_Styles_Print_Order extends WP_UnitTestCase {
+
+	/**
+	 * Reset the global $wp_styles instance before each test so registrations
+	 * made by one test don't leak into another.
+	 * 各テストの前に $wp_styles をリセットし、テスト間で登録内容が
+	 * 引き継がれないようにする.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $wp_styles;
+		$wp_styles = new WP_Styles(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
+
+	/**
+	 * Tear down: reset $wp_styles again to avoid leaking into later test files.
+	 * $wp_styles を再度リセットし、他のテストファイルへの影響を防ぐ.
+	 */
+	public function tear_down() {
+		global $wp_styles;
+		$wp_styles = new WP_Styles(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that wp-block-library is added as a dependency of global-styles
+	 * when both handles are registered.
+	 * 両方のハンドルが登録されている場合に、global-styles の依存関係へ
+	 * wp-block-library が追加されることをテストします.
+	 */
+	public function test_adds_wp_block_library_as_dependency_of_global_styles() {
+		// Register both style handles the way WordPress core does.
+		// WordPress core と同様の形でハンドルを登録.
+		wp_register_style( 'wp-block-library', false );
+		wp_register_style( 'global-styles', false );
+
+		xt9_fix_global_styles_print_order();
+
+		$global_styles = wp_styles()->registered['global-styles'];
+		$this->assertContains( 'wp-block-library', $global_styles->deps, 'wp-block-library が global-styles の依存関係に追加されていない' );
+	}
+
+	/**
+	 * Test that running the function twice does not add the dependency twice (idempotency).
+	 * 2回実行しても依存関係が重複追加されないことをテストします（冪等性）.
+	 */
+	public function test_is_idempotent_when_run_twice() {
+		wp_register_style( 'wp-block-library', false );
+		wp_register_style( 'global-styles', false );
+
+		xt9_fix_global_styles_print_order();
+		xt9_fix_global_styles_print_order();
+
+		$global_styles = wp_styles()->registered['global-styles'];
+		$count         = count(
+			array_filter(
+				$global_styles->deps,
+				static function ( $dep ) {
+					return 'wp-block-library' === $dep;
+				}
+			)
+		);
+		$this->assertSame( 1, $count, 'wp-block-library が重複して追加されている' );
+	}
+
+	/**
+	 * Test that nothing happens (no error, no changes) when global-styles is not registered,
+	 * e.g. on a classic theme where this handle may not exist.
+	 * global-styles が未登録の場合（クラシックテーマ等でハンドルが存在しないケース）
+	 * に、エラーも変更も発生しないことをテストします.
+	 */
+	public function test_does_nothing_when_global_styles_is_not_registered() {
+		wp_register_style( 'wp-block-library', false );
+		// global-styles is intentionally left unregistered.
+		// global-styles は意図的に未登録の状態にする.
+
+		xt9_fix_global_styles_print_order();
+
+		$this->assertArrayNotHasKey( 'global-styles', wp_styles()->registered, '未登録のはずの global-styles が登録されてしまっている' );
+	}
+
+	/**
+	 * Test that nothing happens when wp-block-library is not registered.
+	 * wp-block-library が未登録の場合に、global-styles の依存関係が
+	 * 変更されないことをテストします.
+	 */
+	public function test_does_nothing_when_wp_block_library_is_not_registered() {
+		wp_register_style( 'global-styles', false );
+		// wp-block-library is intentionally left unregistered.
+		// wp-block-library は意図的に未登録の状態にする.
+
+		xt9_fix_global_styles_print_order();
+
+		$global_styles = wp_styles()->registered['global-styles'];
+		$this->assertNotContains( 'wp-block-library', $global_styles->deps, '未登録のはずの wp-block-library が依存関係に追加されてしまっている' );
+	}
+}


### PR DESCRIPTION
## 関連するissue ( VWSフォーラムより )
https://vws.vektor-inc.co.jp/forums/topic/%e8%bf%bd%e5%8a%a0-css-%e3%82%92%e8%a8%ad%e5%ae%9a%e3%81%99%e3%82%8b%e3%81%a8%e3%80%81%e3%82%bf%e3%82%a4%e3%83%88%e3%83%ab%e3%81%ae%e3%83%95%e3%82%a9%e3%83%b3%e3%83%88%e3%82%b5%e3%82%a4%e3%82%ba

## 概要

- WordPress 7.0 で追加された「ブロック単位の追加CSS」機能（高度な設定 > 追加CSS）を使ったブロックがページ内に存在すると、そのページに限って `global-styles`（テーマの `theme.json` によるフルードタイポグラフィ含むグローバルスタイル）が `wp-block-library`（WordPress core の静的フォールバック値。例: `--wp--preset--font-size--huge: 42px;`）より **先に** 出力されてしまい、後から出力される `wp-block-library` の静的値で上書きされてしまう不具合（WordPress core 側のバグ）への暫定対応です。
- 原因: `wp-includes/block-supports/custom-css.php` が新しいスタイルハンドル `wp-block-custom-css` を `global-styles` への依存として登録しているため、WordPress のスタイル依存解決（`WP_Dependencies::do_items()`）が `global-styles` を通常より前に引き上げてしまいます。一方 `wp-block-library` はこの依存グラフに含まれていないため元の位置のまま出力され、結果として順序が逆転します。
- WordPress 7.0（正式版）・7.0.1（ベータ）双方で再現し、既知の Trac / Gutenberg issue は見当たりません。x-t9 の `theme.json` 自体には問題はありません。

## 対応内容

- `inc/global-styles-print-order-fix.php` を新規追加し、`wp_head`（優先度7、`wp_print_styles`（優先度8）の直前）で `global-styles` の依存関係（`deps`）に `wp-block-library` を明示的に追加しました。
- これにより「`wp-block-library` は必ず `global-styles` より先に出力される」という依存関係が常に保証されるため、`wp-block-custom-css` が `global-styles` を引き上げても `wp-block-library` も連動して一緒に引き上げられ、順序が保持されます。
- 依存関係を追加する条件として、`wp-block-library` が「登録済み（`registered`）」であることに加えて「どのみち出力される（`enqueued`。直接 enqueue 済み、または他ハンドルの依存関係経由で間接的に読み込まれる場合を含む）」ことも確認しています。これは、パフォーマンス目的で `wp_dequeue_style( 'wp-block-library' )` を呼んでいるプラグイン・子テーマがあった場合、単に「登録済み」だけで依存関係を追加すると `WP_Dependencies::do_items()` がその dequeue を無効化して `wp-block-library` を強制的に再ロードしてしまう副作用があるため（レビューで指摘）です。フックを `wp_enqueue_scripts` ではなく `wp_head` の優先度7（実際にスタイルが出力される直前）にしているのも、他のプラグイン・子テーマが `wp_enqueue_scripts` のどの優先度で dequeue しても、その最終結果を正しく判定できるようにするためです。
- 「追加CSS」ブロックが使われていないページ・クラシックテーマ相当の状態（`global-styles` ハンドルが存在しない場合）・将来 WordPress core 側でこの不具合が修正された場合でも安全に動作するよう、ハンドルの存在確認と冪等性（重複追加しない）を持たせています。
- `tests/test_xt9_fix_global_styles_print_order.php` に PHPUnit テストを追加しました（直接 enqueue・間接 enqueue・冪等性・ハンドル未登録時の no-op・dequeue 済みハンドルを強制ロードしないことを検証）。
- `readme.txt` の changelog に追記しました（原因が WordPress core 側の不具合であることが分かるよう、「Worked around a WordPress core bug...」という文言にしています）。

## 確認手順

### Before（修正前の再現手順）

1. 固定ページを新規作成し、以下を含むブロックを配置して公開する。
   - 見出しブロック（レベル1）に「フォントサイズ: huge」を設定した見出し（クラス `has-huge-font-size` が付与される）
   - 任意のブロック（例: 段落ブロック）の「高度な設定 > 追加CSS」に何かCSSを1行入力する（例: `.test{color:red}`）
2. 公開後、そのページをブラウザで開き、ページソースを表示する。
3. `<head>` 内の `<style id="wp-block-library-inline-css">` と `<style id="global-styles-inline-css">` の出現順序を確認する。
   → 修正前は `global-styles-inline-css`（`--wp--preset--font-size--huge: clamp(...)`）が `wp-block-library-inline-css`（`--wp--preset--font-size--huge:42px`）より **先** に出力され、後方の `wp-block-library` の `42px` が「後勝ち」してしまう。
4. 見出し要素をブラウザの検証ツールで確認すると、`font-size` が theme.json のフルード値ではなく固定 42px 相当になっている。

### After（修正後の確認手順）

1. 本PRを適用した状態で、上記と同じ手順1〜2を行う。
2. `<head>` 内の出現順序を確認する。
   → `wp-block-library-inline-css`（`42px`）が **先**、`global-styles-inline-css`（`clamp(...)`）が **後** の順に出力され、見出しの `font-size` が theme.json 通りのフルード値（clamp）で描画される。
3. デグレ確認: 追加CSSブロックを使っていない通常ページでも同じ順序（`wp-block-library` → `global-styles`）で出力され、表示に変化がないことを確認する。
4. dequeue デグレ確認: `wp_dequeue_style( 'wp-block-library' )` を呼ぶダミーコードを一時的に足した状態でページを取得し、`wp-block-library` 関連のスタイルタグが一切出力されない（強制的に再ロードされない）ことを確認する。

上記はローカル環境（Local, WordPress 7.0.1-RC1）で実際に固定ページを作成し、`wp-cli`・`curl` によるページソース取得で本PRの適用前後を確認済みです（検証用ページ・ダミーコードは確認後に削除済みです）。

## 補足

- 表示への影響は theme.json で定義したフルードタイポグラフィの数値差分（今回の環境では clamp(28.16px, ..., 32.18px) vs 42px）のみで、レイアウト崩れ等を伴う視覚的な差分ではないため、スクリーンショットは省略し、上記のCSS出力順序・値によるテキストベースの確認手順を記載しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WordPress 7.0+ のブロック追加CSS利用時に、テーマの流動的タイポグラフィが静的フォールバック値で表示される不具合を回避・改善しました。
* **Tests**
  * 依存関係の追加有無、重複防止、未登録時・非表示状態での挙動を確認する自動テストを追加しました。
* **Documentation**
  * リリースノートに本件の不具合修正（回避）内容を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
