### PR TITLE
[ デザイン不具合修正 ][ Snow Monkey Forms ] 固定ヘッダー使用時にSnow Monkey Formsの画面遷移後にフォーム先頭がヘッダーの下に隠れる不具合を修正

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -207,9 +207,19 @@ function x_t9_enqueue_snow_monkey_forms_js() {
 	// same wp_enqueue_scripts hook, but since plugins are always loaded before
 	// a theme's functions.php, the handle is guaranteed to already be
 	// registered at this point.
+	$js = file_get_contents( get_template_directory() . '/plugin-support/snow-monkey-forms/js/smf-fixed-header-offset.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+	// ファイル読み込みに失敗した場合は false が返るため、インラインスクリプトとして
+	// "false" 相当の値を出力してしまわないようにガードする.
+	// file_get_contents() returns false on failure; guard against passing that
+	// straight into wp_add_inline_script() as the script body.
+	if ( false === $js ) {
+		return;
+	}
+
 	wp_add_inline_script(
 		'snow-monkey-forms',
-		file_get_contents( get_template_directory() . '/plugin-support/snow-monkey-forms/js/smf-fixed-header-offset.js' ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$js
 	);
 }
 add_action( 'wp_enqueue_scripts', 'x_t9_enqueue_snow_monkey_forms_js' );

--- a/functions.php
+++ b/functions.php
@@ -175,6 +175,46 @@ function x_t9_enqueue_snow_monkey_forms_css() {
 add_action( 'wp_enqueue_scripts', 'x_t9_enqueue_snow_monkey_forms_css' );
 
 /**
+ * Fixed header 使用時、Snow Monkey Forms の画面遷移後のスクロール位置が
+ * ヘッダーの下に隠れてしまう問題への対応として、補正用 JS を Snow Monkey
+ * Forms 本体のスクリプト（ハンドル: snow-monkey-forms）にインラインで追加する。
+ *
+ * Adds an inline script to Snow Monkey Forms' own script (handle:
+ * snow-monkey-forms) that corrects the scroll position after a screen
+ * transition when using a fixed header, so the top of the form is not
+ * hidden behind the header.
+ *
+ * @return void
+ */
+function x_t9_enqueue_snow_monkey_forms_js() {
+	// Snow Monkey Forms が有効でない場合は何もしない.
+	// Do nothing when Snow Monkey Forms is not active.
+	if ( ! class_exists( 'Snow_Monkey\Plugin\Forms\Bootstrap' ) ) {
+		return;
+	}
+
+	// テーマ側でこのスクロール位置補正を無効化したい場合に利用できるフィルター.
+	// A filter hook for disabling this scroll position adjustment from a child theme or plugin.
+	if ( ! apply_filters( 'x_t9_smf_fixed_header_offset', true ) ) {
+		return;
+	}
+
+	// Snow Monkey Forms 本体（ハンドル: snow-monkey-forms）は本関数と同じ
+	// wp_enqueue_scripts フックで登録されるが、プラグインは常にテーマの
+	// functions.php より先に読み込まれるため、この時点で登録済みであることが
+	// 保証されている.
+	// Snow Monkey Forms itself registers the "snow-monkey-forms" handle on the
+	// same wp_enqueue_scripts hook, but since plugins are always loaded before
+	// a theme's functions.php, the handle is guaranteed to already be
+	// registered at this point.
+	wp_add_inline_script(
+		'snow-monkey-forms',
+		file_get_contents( get_template_directory() . '/plugin-support/snow-monkey-forms/js/smf-fixed-header-offset.js' ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	);
+}
+add_action( 'wp_enqueue_scripts', 'x_t9_enqueue_snow_monkey_forms_js' );
+
+/**
  * Navigation Submenu block do render menu item description
  * 6.8がリリースされたら削除する
  */

--- a/plugin-support/snow-monkey-forms/js/smf-fixed-header-offset.js
+++ b/plugin-support/snow-monkey-forms/js/smf-fixed-header-offset.js
@@ -1,0 +1,104 @@
+/**
+ * Snow Monkey Forms fixed header offset adjustment.
+ * 固定ヘッダー使用時の Snow Monkey Forms スクロール位置補正。
+ *
+ * Snow Monkey Forms (SMF) scrolls the screen to `.smf-focus-point` with
+ * `window.scrollTo()` when the form transitions between screens (confirm,
+ * complete, back), but it does not account for the height of a fixed
+ * header. On sites using the X-T9 fixed header pattern
+ * (`header.is-position-fixed`), this causes the top of the form to be
+ * hidden behind the header after the screen transition.
+ * Snow Monkey Forms（以下 SMF）はフォームの画面遷移時（確認画面・完了画面・
+ * 戻る）に `window.scrollTo()` で `.smf-focus-point` までスクロールするが、
+ * 固定ヘッダーの高さを考慮していない。そのため X-T9 の固定ヘッダーパターン
+ * （`header.is-position-fixed`）を使用しているサイトでは、画面遷移後に
+ * フォームの先頭がヘッダーの下に隠れてしまう。
+ *
+ * This script listens for the SMF custom events fired only when SMF itself
+ * scrolls to the focus point (`smf.confirm` / `smf.complete` / `smf.back`)
+ * and re-scrolls to the same focus point, subtracting the fixed header
+ * height (and, for logged-in users, the admin bar height) from the target
+ * position.
+ * このスクリプトでは、SMF が実際にフォーカスポイントへスクロールする
+ * タイミングでのみ発火するカスタムイベント（`smf.confirm` / `smf.complete` /
+ * `smf.back`）を監視し、同じフォーカスポイントへ固定ヘッダーの高さ
+ * （ログインユーザーの場合は管理バーの高さも）分だけ差し引いた位置へ
+ * 再スクロールする。
+ *
+ * Note: `smf.submit` also fires for the `invalid` screen (validation
+ * errors on the input screen), but in that case SMF moves focus to the
+ * first invalid control instead of scrolling to the focus point. Using
+ * `smf.submit` here would incorrectly override that focus behavior, so
+ * only the three events above (which always accompany an actual scroll to
+ * the focus point) are used.
+ * 補足: `smf.submit` は入力エラー時（`invalid` 画面）でも発火するが、その
+ * ケースでは SMF はフォーカスポイントへのスクロールではなく、最初の
+ * エラー項目へフォーカスを移動する。`smf.submit` を使うとこのフォーカス
+ * 挙動を誤って上書きしてしまうため、実際にフォーカスポイントへ
+ * スクロールする上記 3 イベントのみを対象にしている。
+ *
+ * Scope: only the fixed header pattern (`is-position-fixed`) is supported.
+ * The `scrolled-header-fixed` pattern (header that appears on scroll) and
+ * headers whose height changes dynamically (e.g. shrink on scroll) are out
+ * of scope.
+ * 対象範囲: `is-position-fixed` の固定ヘッダーパターンのみ対応する。
+ * スクロールで出現する `scrolled-header-fixed` パターンや、スクロールに
+ * 応じて高さが動的に変化するヘッダー（shrink on scroll 等）は対象外。
+ */
+( function () {
+	'use strict';
+
+	/**
+	 * Re-scroll to the SMF focus point, offset by the fixed header height.
+	 * SMF のフォーカスポイントへ、固定ヘッダーの高さ分を差し引いて再スクロールする。
+	 *
+	 * @param {CustomEvent} event The `smf.confirm` / `smf.complete` / `smf.back` event
+	 *                            fired on the form element.
+	 *                            フォーム要素で発火する `smf.confirm` / `smf.complete` /
+	 *                            `smf.back` イベント。
+	 */
+	function adjustScrollForFixedHeader( event ) {
+		var form = event.target;
+		var focusPoint = form.querySelector( '.smf-focus-point' );
+		var fixedHeader = document.querySelector( 'header.is-position-fixed' );
+
+		// No focus point or no fixed header on this page: nothing to adjust.
+		// フォーカスポイントが無い、または固定ヘッダーが無いページでは補正不要。
+		if ( ! focusPoint || ! fixedHeader ) {
+			return;
+		}
+
+		// Measure the header height every time instead of caching it, so
+		// this also works correctly when the header height differs between
+		// PC and mobile (responsive layouts).
+		// PC とスマホでヘッダー高さが異なるレスポンシブ構成にも対応できるよう、
+		// キャッシュせずイベント発火のたびに実測する。
+		var headerHeight = fixedHeader.offsetHeight;
+
+		// WordPress core exposes the admin bar height (32px, or 46px on
+		// narrow viewports) as a CSS custom property for logged-in users.
+		// It is empty (falls back to 0) when the admin bar is not shown.
+		// WordPress コアはログインユーザー向けに管理バーの高さ（32px、狭い
+		// ビューポートでは 46px）を CSS カスタムプロパティとして公開している。
+		// 管理バーが表示されない場合は空文字になり、0 にフォールバックする。
+		var adminBarHeight =
+			parseInt(
+				getComputedStyle( document.documentElement ).getPropertyValue(
+					'--wp-admin--admin-bar--height'
+				) || '0',
+				10
+			) || 0;
+
+		var targetY =
+			window.pageYOffset +
+			focusPoint.getBoundingClientRect().top -
+			headerHeight -
+			adminBarHeight;
+
+		window.scrollTo( 0, targetY );
+	}
+
+	[ 'smf.confirm', 'smf.complete', 'smf.back' ].forEach( function ( eventName ) {
+		document.addEventListener( eventName, adjustScrollForFixedHeader, false );
+	} );
+} )();

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ GitHub : https://github.com/vektor-inc/x-t9
 
 == Changelog ==
 
+[ Design Bug Fix ][ Snow Monkey Forms ] Fixed an issue where, when using a fixed header pattern (is-position-fixed), the top of the form was hidden behind the header after a Snow Monkey Forms screen transition (confirm/complete/back)
+
 = 1.41.7 =
 [ Bug Fix ] Fixed PHP warning recorded when accessing an archive of an unregistered post type on PHP 8.0 or later
 [ Bug Fix ] Worked around a WordPress core bug (7.0+) that caused headings using fluid typography to render at a fixed font size instead of the theme's fluid clamp() value when a block's Additional CSS was used


### PR DESCRIPTION
## 概要

X-T9で固定ヘッダーパターン（`is-position-fixed`）を使用している場合、Snow Monkey Forms（SMF）のフォーム送信後の画面遷移（確認画面・完了画面・戻る操作）時に、フォームの先頭（`.smf-focus-point`）が固定ヘッダーの下に隠れてしまう不具合を修正しました。

SMFの `focusFocusPoint()` がスクロール位置を計算する際、固定ヘッダーの高さを考慮していないことが原因です。SMF本体は変更せず、テーマ側でSMFのカスタムイベント（`smf.confirm` / `smf.complete` / `smf.back`）を利用してスクロール位置をヘッダー高さ分補正しています。

## 実装内容

- `functions.php`: `x_t9_enqueue_snow_monkey_forms_js()` を追加。SMF有効時のみ、`x_t9_smf_fixed_header_offset` フィルターで無効化可能な形で、補正用JSを `wp_add_inline_script` で `snow-monkey-forms` ハンドルに注入
- `plugin-support/snow-monkey-forms/js/smf-fixed-header-offset.js`（新規）: `smf.confirm` / `smf.complete` / `smf.back` イベントをリスンし、固定ヘッダー高さ（管理バー分含む）を差し引いた位置へ再スクロール
  - イメージコードでは `smf.submit` を想定していましたが、実装時にSMF本体のソースを確認したところ `smf.submit` は入力エラー時（エラー項目へのフォーカス）にも発火し、無条件補正だとこの既存のアクセシビリティ挙動を上書きしてしまうため、実際にフォーカスポイントへスクロールする `smf.confirm` / `smf.complete` / `smf.back` の3イベントに変更しています

### 対応スコープ

- 対象: `is-position-fixed` クラスを持つ固定ヘッダーのみ
- 対象外: `scrolled-header-fixed` パターン、ヘッダー高さが動的に変化する構成（shrink on scroll等）
- `smf.systemerror`（サーバーエラー画面）も同種の問題が起きうりますが、今回のスコープ外としています。必要であれば別issueで検討します

## 確認手順

### 前提条件

- Snow Monkey Forms プラグインを有効化
- 固定ヘッダーパターン（`is-position-fixed`）を使用したページに Snow Monkey Form ブロックを配置

### Before（修正前の再現手順）

1. 固定ヘッダー使用ページでフォームを入力し送信する
2. 確認画面 / 完了画面へ遷移する
   → ✗ フォームの先頭（`.smf-focus-point`）が固定ヘッダーの下に隠れる

### After（修正後）

1. 固定ヘッダー使用ページでフォームを入力し送信する
2. 確認画面へ遷移する
   → ✓ フォーム先頭が固定ヘッダーの下端（ログイン時は管理バーの高さも含む）に正しく表示される
3. 確認画面から送信し、完了画面へ遷移する
   → ✓ 同様に正しく表示される
4. 確認画面で「戻る」を押し入力画面へ戻る
   → ✓ 同様に正しく表示される
5. `x_t9_smf_fixed_header_offset` フィルターを `false` にする
   → ✓ 補正用JSがページに出力されなくなる（機能を無効化できる）
6. Snow Monkey Forms プラグインを無効化した状態でページを表示する
   → ✓ エラーが出ず、既存動作に影響がない

### デグレ確認

- 固定ヘッダーを使用していないページでフォームを送信する → 従来通りの動作（補正なし）に影響がないこと

## スクリーンショット

本修正はスクロール位置の補正（動きの確認が必要な変更）のため、静止画よりGIFでの確認が適しています。`review-assets` への画像・GIFのコミットはテスト担当（麗美）のみに許可されているため、e2eテストのレポート（PRコメント）にBefore/AfterのGIFを添付予定です。

## 関連issue

関連 issue: https://github.com/vektor-inc/x-t9/issues/465

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 固定ヘッダー（固定ヘッダー設定）を使用している環境で、confirm/complete/back の画面遷移後にフォーム上部がヘッダーに隠れる問題を修正しました。  
  * 画面遷移後のスクロール位置を調整し、フォーム内容が見えやすくなるよう改善しました。  
  * 管理バー表示時も、表示の見切れを抑えるようオフセットを補正しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->