### PR TITLE
[ デザイン不具合修正 ] 固定ヘッダー使用時に目次ブロック等のページ内リンク・フォーカス時のスクロール位置がヘッダーに隠れる不具合を修正

### DIFF
--- a/assets/_js/_master.js
+++ b/assets/_js/_master.js
@@ -113,3 +113,55 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 });
+
+
+/*----------------------------------------------------------*/
+/*  fixed header height => CSS custom property
+/*----------------------------------------------------------*/
+// header.is-position-fixed（常時固定ヘッダーパターン）の高さをリアルタイムに監視し、
+// --x-t9-fixed-header-height という CSS カスタムプロパティに反映する。
+// これにより、目次ブロックなどページ内リンクのジャンプ先や :focus 時に scroll-margin-block-start で
+// 実際のヘッダー高さ分だけ正確にスクロール位置を補正できるようになる
+// （PC/スマホでヘッダー高さが異なるレスポンシブ構成にも自動で追従する）。
+// 対象範囲: header.is-position-fixed（常時固定ヘッダー）のみ。
+// is-style-scrolled-header-fixed（スクロールで出現する高さ可変ヘッダー）は対象外。
+//
+// Watches the height of header.is-position-fixed (the always-fixed header pattern) in real
+// time and reflects it into the --x-t9-fixed-header-height CSS custom property, so
+// scroll-margin-block-start (used e.g. by in-page links from the Table of Contents block, and
+// by :focus for keyboard navigation) can offset the scroll position by the exact header height
+// (automatically tracking responsive layouts where the header height differs between PC and
+// mobile).
+// Scope: only header.is-position-fixed (the always-fixed header pattern) is supported;
+// is-style-scrolled-header-fixed (a variable-height header that appears on scroll) is out of
+// scope.
+(() => {
+    'use strict';
+
+    // ResizeObserver 未対応ブラウザでは何もしない（CSS 側の var() フォールバックで 0px のまま動作する）
+    // Do nothing in browsers without ResizeObserver support (the CSS var() fallback keeps it at 0px)
+    if (typeof ResizeObserver === 'undefined') {
+        return;
+    }
+
+    const fixedHeader = document.querySelector('header.is-position-fixed');
+
+    // 固定ヘッダーが存在しないページでは何もしない（変数未設定のままフォールバック値の0pxが使われる）
+    // Do nothing on pages without a fixed header (the variable stays unset and falls back to 0px)
+    if (!fixedHeader) {
+        return;
+    }
+
+    const resizeObserver = new ResizeObserver((entries) => {
+        entries.forEach((entry) => {
+            // offsetHeight は border / padding を含む実際の表示高さのため使用する
+            // Use offsetHeight since it includes border/padding and reflects the actual rendered height
+            document.documentElement.style.setProperty(
+                '--x-t9-fixed-header-height',
+                entry.target.offsetHeight + 'px'
+            );
+        });
+    });
+
+    resizeObserver.observe(fixedHeader);
+})();

--- a/assets/_js/_master.js
+++ b/assets/_js/_master.js
@@ -118,23 +118,37 @@ document.addEventListener('DOMContentLoaded', function() {
 /*----------------------------------------------------------*/
 /*  fixed header height => CSS custom property
 /*----------------------------------------------------------*/
-// header.is-position-fixed（常時固定ヘッダーパターン）の高さをリアルタイムに監視し、
-// --x-t9-fixed-header-height という CSS カスタムプロパティに反映する。
+// ヘッダーが画面上に重なって表示される複数のパターン（常時固定 / sticky / スクロールで出現）の
+// 高さをリアルタイムに監視し、--x-t9-fixed-header-height という CSS カスタムプロパティに反映する。
 // これにより、目次ブロックなどページ内リンクのジャンプ先や :focus 時に scroll-margin-block-start で
 // 実際のヘッダー高さ分だけ正確にスクロール位置を補正できるようになる
 // （PC/スマホでヘッダー高さが異なるレスポンシブ構成にも自動で追従する）。
-// 対象範囲: header.is-position-fixed（常時固定ヘッダー）のみ。
-// is-style-scrolled-header-fixed（スクロールで出現する高さ可変ヘッダー）は対象外。
+// 対象範囲:
+//   1. header.is-position-fixed        … 常時固定ヘッダー
+//   2. header:has([class*="is-position-sticky"]) … sticky ヘッダー（張り付いていない間も通常フロー内で
+//      何にも重ならないため、常に高さを反映してよい）
+//   3. *[class*="scrolled-header-fixed"] … スクロールで出現するヘッダー（body に
+//      .header-fixed-active が付与されている間だけ画面内に現れるため、そのクラスがある時だけ高さを
+//      反映し、外れたら即座に 0 へ戻す。戻さないと、ヘッダーが画面外へ退避した後も
+//      scroll-margin-block-start の余白だけが残る「ゴーストスペース」が発生するため）
+// 複数パターンが同時に該当するサイトでも極端に壊れないよう、各パターンの高さのうち最大値を採用する。
 //
-// Watches the height of header.is-position-fixed (the always-fixed header pattern) in real
-// time and reflects it into the --x-t9-fixed-header-height CSS custom property, so
-// scroll-margin-block-start (used e.g. by in-page links from the Table of Contents block, and
-// by :focus for keyboard navigation) can offset the scroll position by the exact header height
-// (automatically tracking responsive layouts where the header height differs between PC and
-// mobile).
-// Scope: only header.is-position-fixed (the always-fixed header pattern) is supported;
-// is-style-scrolled-header-fixed (a variable-height header that appears on scroll) is out of
-// scope.
+// Watches the height of the header patterns that can visually overlap page content (always-fixed /
+// sticky / scroll-triggered) in real time and reflects it into the --x-t9-fixed-header-height CSS
+// custom property, so scroll-margin-block-start (used e.g. by in-page links from the Table of
+// Contents block, and by :focus for keyboard navigation) can offset the scroll position by the
+// exact header height (automatically tracking responsive layouts where the header height differs
+// between PC and mobile).
+// Scope:
+//   1. header.is-position-fixed                    … the always-fixed header
+//   2. header:has([class*="is-position-sticky"])  … the sticky header (it never overlaps content
+//      while unstuck, since it stays in normal flow, so its height can always be reflected)
+//   3. *[class*="scrolled-header-fixed"]           … the header that appears on scroll only while
+//      body has the .header-fixed-active class; its height is reflected only while that class is
+//      present and reset to 0 immediately once it's removed, otherwise the scroll-margin-block-start
+//      offset would leave a "ghost gap" behind after the header slides off-screen again
+// If a site somehow matches more than one pattern at once, the highest of the matched heights is
+// used so the result stays reasonable without extra complexity.
 (() => {
     'use strict';
 
@@ -144,24 +158,105 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
+    // パターンごとの高さを保持し、複数該当時は最大値を採用する
+    // Keep each pattern's height separately; when multiple patterns match, the maximum is used
+    const headerHeights = {
+        fixed: 0,
+        sticky: 0,
+        scrolled: 0,
+    };
+
+    // 保持している最大値を CSS カスタムプロパティへ反映する
+    // Reflect the current maximum height into the CSS custom property
+    const applyMaxHeaderHeight = () => {
+        const maxHeight = Math.max(headerHeights.fixed, headerHeights.sticky, headerHeights.scrolled);
+        document.documentElement.style.setProperty(
+            '--x-t9-fixed-header-height',
+            maxHeight + 'px'
+        );
+    };
+
+    /* header.is-position-fixed（常時固定ヘッダー）
+       ---------------------------------------------------------- */
     const fixedHeader = document.querySelector('header.is-position-fixed');
 
-    // 固定ヘッダーが存在しないページでは何もしない（変数未設定のままフォールバック値の0pxが使われる）
-    // Do nothing on pages without a fixed header (the variable stays unset and falls back to 0px)
-    if (!fixedHeader) {
-        return;
+    if (fixedHeader) {
+        const fixedHeaderObserver = new ResizeObserver((entries) => {
+            entries.forEach((entry) => {
+                // offsetHeight は border / padding を含む実際の表示高さのため使用する
+                // Use offsetHeight since it includes border/padding and reflects the actual rendered height
+                headerHeights.fixed = entry.target.offsetHeight;
+                applyMaxHeaderHeight();
+            });
+        });
+
+        fixedHeaderObserver.observe(fixedHeader);
     }
 
-    const resizeObserver = new ResizeObserver((entries) => {
-        entries.forEach((entry) => {
-            // offsetHeight は border / padding を含む実際の表示高さのため使用する
-            // Use offsetHeight since it includes border/padding and reflects the actual rendered height
-            document.documentElement.style.setProperty(
-                '--x-t9-fixed-header-height',
-                entry.target.offsetHeight + 'px'
-            );
-        });
-    });
+    /* header:has([class*="is-position-sticky"])（sticky ヘッダー）
+       ---------------------------------------------------------- */
+    // :has() 未対応ブラウザでは querySelector が例外を投げるため try/catch で無視する
+    // （CSS 側の :has() も効かず sticky にならないため、影響はない）
+    // In browsers without :has() support querySelector throws, so ignore it via try/catch
+    // (the CSS :has() rule won't apply either, so the header won't be sticky there — no impact)
+    let stickyHeader = null;
 
-    resizeObserver.observe(fixedHeader);
+    try {
+        stickyHeader = document.querySelector('header:has([class*="is-position-sticky"])');
+    } catch (e) {
+        stickyHeader = null;
+    }
+
+    if (stickyHeader) {
+        const stickyHeaderObserver = new ResizeObserver((entries) => {
+            entries.forEach((entry) => {
+                headerHeights.sticky = entry.target.offsetHeight;
+                applyMaxHeaderHeight();
+            });
+        });
+
+        stickyHeaderObserver.observe(stickyHeader);
+    }
+
+    /* *[class*="scrolled-header-fixed"]（スクロールで出現するヘッダー）
+       ---------------------------------------------------------- */
+    const scrolledHeader = document.querySelector('[class*="scrolled-header-fixed"]');
+
+    if (scrolledHeader) {
+        // ResizeObserver のコールバックは body に .header-fixed-active が無い間も発火し得るため、
+        // 実測した高さを一旦保持しておき、反映するかどうかは MutationObserver 側の判定に委ねる
+        // The ResizeObserver callback can fire even while body lacks .header-fixed-active, so the
+        // measured height is cached here and whether to apply it is left to the MutationObserver below
+        let scrolledHeaderMeasuredHeight = 0;
+
+        const scrolledHeaderObserver = new ResizeObserver((entries) => {
+            entries.forEach((entry) => {
+                scrolledHeaderMeasuredHeight = entry.target.offsetHeight;
+
+                if (document.body.classList.contains('header-fixed-active')) {
+                    headerHeights.scrolled = scrolledHeaderMeasuredHeight;
+                    applyMaxHeaderHeight();
+                }
+            });
+        });
+
+        scrolledHeaderObserver.observe(scrolledHeader);
+
+        // 既存の header_scrool_func を直接改変せず、body の class 属性の変化だけを独立して監視し、
+        // header-fixed-active の有無に応じて反映 / クリア（0へリセット）する
+        // Watch body's class attribute independently instead of modifying the existing
+        // header_scrool_func, and reflect / clear (reset to 0) the height depending on whether
+        // header-fixed-active is present
+        const bodyClassObserver = new MutationObserver(() => {
+            headerHeights.scrolled = document.body.classList.contains('header-fixed-active')
+                ? scrolledHeaderMeasuredHeight
+                : 0;
+            applyMaxHeaderHeight();
+        });
+
+        bodyClassObserver.observe(document.body, {
+            attributes: true,
+            attributeFilter: ['class'],
+        });
+    }
 })();

--- a/assets/_scss/_common_margin-vertical.scss
+++ b/assets/_scss/_common_margin-vertical.scss
@@ -1,11 +1,17 @@
 /* ページ内リンクのスムーススクロールでヘッダーの高さ分スクロール位置を調整するためのマージン */
 /* To adjust the scroll position by the height of the header for smooth scrolling of the page link */
-/* --x-t9-fixed-header-height は header.is-position-fixed（常時固定ヘッダーパターン）使用時のみ、
-   assets/_js/_master.js の ResizeObserver によって実際のヘッダー高さにリアルタイムで更新される。
-   固定ヘッダー未使用のサイトでは変数が設定されないため、フォールバックの 0px となり影響しない。 */
+/* --x-t9-fixed-header-height は、画面上に重なって表示され得るヘッダーパターン
+   （header.is-position-fixed の常時固定ヘッダー / header:has([class*="is-position-sticky"]) の
+   sticky ヘッダー / *[class*="scrolled-header-fixed"] のスクロールで出現するヘッダー）使用時に、
+   assets/_js/_master.js の ResizeObserver（スクロールで出現するパターンは MutationObserver も併用）
+   によって実際のヘッダー高さにリアルタイムで更新される。
+   いずれのパターンも未使用のサイトでは変数が設定されないため、フォールバックの 0px となり影響しない。 */
 /* --x-t9-fixed-header-height is updated in real time to the actual header height by the
-   ResizeObserver in assets/_js/_master.js, but only when header.is-position-fixed (the
-   always-fixed header pattern) is used. On sites without a fixed header the variable is
+   ResizeObserver (plus a MutationObserver for the scroll-triggered pattern) in
+   assets/_js/_master.js, whenever one of the header patterns that can overlap page content is
+   used (the always-fixed header.is-position-fixed, the sticky
+   header:has([class*="is-position-sticky"]), or the scroll-triggered
+   *[class*="scrolled-header-fixed"]). On sites using none of these patterns the variable is
    never set, so it falls back to 0px and has no effect. */
 :where([id], :focus) {
 	scroll-margin-block-start: var(--x-t9-fixed-header-height, 0px);

--- a/assets/_scss/_common_margin-vertical.scss
+++ b/assets/_scss/_common_margin-vertical.scss
@@ -1,8 +1,22 @@
 /* ページ内リンクのスムーススクロールでヘッダーの高さ分スクロール位置を調整するためのマージン */
 /* To adjust the scroll position by the height of the header for smooth scrolling of the page link */
-/* 本当は js でヘッダー高さを監視してCSS変数に入れた方が正確だが、汎用につき余計な不具合が発生しないようにCSSのみ */
+/* --x-t9-fixed-header-height は header.is-position-fixed（常時固定ヘッダーパターン）使用時のみ、
+   assets/_js/_master.js の ResizeObserver によって実際のヘッダー高さにリアルタイムで更新される。
+   固定ヘッダー未使用のサイトでは変数が設定されないため、フォールバックの 0px となり影響しない。 */
+/* --x-t9-fixed-header-height is updated in real time to the actual header height by the
+   ResizeObserver in assets/_js/_master.js, but only when header.is-position-fixed (the
+   always-fixed header pattern) is used. On sites without a fixed header the variable is
+   never set, so it falls back to 0px and has no effect. */
 :where([id], :focus) {
-	scroll-margin-block-start: 85px;
+	scroll-margin-block-start: var(--x-t9-fixed-header-height, 0px);
+}
+
+/* 印刷時は固定ヘッダーが存在しないため、スクロール位置補正を無効化する */
+/* Disable the scroll position adjustment when printing, since there is no fixed header on the printed page */
+@media print {
+	:where([id], :focus) {
+		scroll-margin-block-start: 0;
+	}
 }
 
 /**

--- a/assets/_scss/_variables.scss
+++ b/assets/_scss/_variables.scss
@@ -10,6 +10,15 @@ $lg-min: 992px;
 $xl-min: 1200px;
 $xxl-min: 1400px;
 
+:root {
+	// 固定ヘッダー（header.is-position-fixed）の高さ。assets/_js/_master.js の ResizeObserver によって
+	// リアルタイムに更新される。JS 実行前や固定ヘッダー未使用時にガタつかないよう初期値を 0px にしておく。
+	// Height of the fixed header (header.is-position-fixed), updated in real time by the ResizeObserver
+	// in assets/_js/_master.js. Defaulted to 0px so there is no layout shift before the JS runs or on
+	// sites that don't use a fixed header.
+	--x-t9-fixed-header-height: 0px;
+}
+
 body {
 	--vk-size-radius: var(--wp--custom--radius--button);
 	--vk-color-border-light: var(--wp--preset--color--border-normal);

--- a/assets/_scss/_variables.scss
+++ b/assets/_scss/_variables.scss
@@ -11,11 +11,13 @@ $xl-min: 1200px;
 $xxl-min: 1400px;
 
 :root {
-	// 固定ヘッダー（header.is-position-fixed）の高さ。assets/_js/_master.js の ResizeObserver によって
-	// リアルタイムに更新される。JS 実行前や固定ヘッダー未使用時にガタつかないよう初期値を 0px にしておく。
-	// Height of the fixed header (header.is-position-fixed), updated in real time by the ResizeObserver
-	// in assets/_js/_master.js. Defaulted to 0px so there is no layout shift before the JS runs or on
-	// sites that don't use a fixed header.
+	// 画面上に重なって表示され得るヘッダー（常時固定 / sticky / スクロールで出現）の高さ。
+	// assets/_js/_master.js の ResizeObserver（＋MutationObserver）によってリアルタイムに更新される。
+	// JS 実行前やいずれのパターンも未使用時にガタつかないよう初期値を 0px にしておく。
+	// Height of the header patterns that can overlap page content (always-fixed / sticky /
+	// scroll-triggered), updated in real time by the ResizeObserver (plus a MutationObserver) in
+	// assets/_js/_master.js. Defaulted to 0px so there is no layout shift before the JS runs or on
+	// sites using none of these patterns.
 	--x-t9-fixed-header-height: 0px;
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 == Changelog ==
 
 [ Design Bug Fix ][ Snow Monkey Forms ] Fixed an issue where, when using a fixed header pattern (is-position-fixed), the top of the form was hidden behind the header after a Snow Monkey Forms screen transition (confirm/complete/back)
-[ Design Bug Fix ] Fixed in-page link jumps (e.g. from the Table of Contents block) and keyboard focus landing behind a fixed header (is-position-fixed), by having scroll-margin-block-start track the real header height in real time instead of a hardcoded 85px value
+[ Design Bug Fix ] Fixed in-page link jumps (e.g. from the Table of Contents block) and keyboard focus landing behind a fixed, sticky, or scroll-triggered header, by having scroll-margin-block-start track the real header height in real time instead of a hardcoded 85px value
 
 = 1.41.7 =
 [ Bug Fix ] Fixed PHP warning recorded when accessing an archive of an unregistered post type on PHP 8.0 or later

--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,7 @@ GitHub : https://github.com/vektor-inc/x-t9
 == Changelog ==
 
 [ Design Bug Fix ][ Snow Monkey Forms ] Fixed an issue where, when using a fixed header pattern (is-position-fixed), the top of the form was hidden behind the header after a Snow Monkey Forms screen transition (confirm/complete/back)
+[ Design Bug Fix ] Fixed in-page link jumps (e.g. from the Table of Contents block) and keyboard focus landing behind a fixed header (is-position-fixed), by having scroll-margin-block-start track the real header height in real time instead of a hardcoded 85px value
 
 = 1.41.7 =
 [ Bug Fix ] Fixed PHP warning recorded when accessing an archive of an unregistered post type on PHP 8.0 or later


### PR DESCRIPTION
## 概要

固定ヘッダー（`header.is-position-fixed`）使用時、ページ内リンク（目次ブロックのリンク等）やキーボード操作時のフォーカス移動で、ジャンプ先の見出しが固定ヘッダーに隠れてしまう不具合を修正しました。

原因は `assets/_scss/_common_margin-vertical.scss` の `scroll-margin-block-start` が `85px` の固定値になっており、実際のヘッダー高さ（サイトごとに異なる）とズレていたことです。本PRでは、`header.is-position-fixed` の高さを `ResizeObserver` でリアルタイムに監視し、CSSカスタムプロパティ `--x-t9-fixed-header-height` へ反映する方式に変更しました。固定ヘッダー未使用のサイトでは変数が設定されないため `0px` にフォールバックし、影響はありません。

**追記（レビュー対応）:** 上記の初期実装は `header.is-position-fixed` のみを対象にしていましたが、`_block_styles.scss` で現役サポートされている他のヘッダーパターンでもオフセットが必要なため、対象を以下の2パターンに拡張しました。

- `header:has([class*="is-position-sticky"])`（sticky ヘッダー）… 張り付いていない間も通常フロー内にあり何にも重ならないため、常時反映します。
- `*[class*="scrolled-header-fixed"]`（スクロールで出現するヘッダー）… `body.header-fixed-active` が付与されている間だけ画面内に現れるため、そのクラスの有無を `MutationObserver` で監視し、該当時のみ高さを反映・非該当時は即座に0へリセットします。これにより、ヘッダーが画面外へ退避した後もオフセット分の余白（ゴーストスペース）が残ってしまう既存バグも同時に解消しています。
- 複数パターンが同時に該当する場合は、各パターンの高さのうち最大値を採用します。

なお、本issueの症状としてはもう1つ別の原因（別プラグイン `vk-all-in-one-expansion-unit` のスムーススクロール機能がこのCSSを無視して独自スクロールする問題）があり、そちらは別リポジトリの問題のため本PRのスコープ外です。別途 [vektor-inc/vk-all-in-one-expansion-unit#1421](https://github.com/vektor-inc/vk-all-in-one-expansion-unit/issues/1421) で対応検討中です。

関連 issue: https://github.com/vektor-inc/x-t9/issues/384

## 確認手順

前提: 固定ページ等に目次ブロック（またはページ内リンク）と、複数の見出しを設置し、ヘッダーの位置設定を「固定」にしておく。

### Before（修正前 / master ブランチ）との比較

1. `master` ブランチで `npm run build:css` を実行し、ビルドする
2. 目次ブロックを設置したページをフロントで開き、目次のリンクをクリックする
   → ジャンプ先の見出しの上端が、実際のヘッダー高さと固定値85pxの差分（環境依存、検証環境では約15px）だけヘッダーに隠れた状態で止まる

### After（本PR）の確認

1. 本ブランチをチェックアウトし、`npm run build:css && npm run build:script` を実行する
2. 同じページで目次のリンクをクリックする
   → ジャンプ先の見出しの上端が、実際のヘッダー下端とほぼ隙間なく一致する位置で止まる（検証環境でのPlaywright実測: 修正前 -15px 〜 -100px の重なり → 修正後 約-0.45px まで改善）
3. ブラウザの開発者ツールで `getComputedStyle(document.documentElement).getPropertyValue('--x-t9-fixed-header-height')` を確認し、実際のヘッダー高さ（px）が反映されていることを確認する
4. ヘッダーを使用しないページ（ヘッダー位置設定が「固定」以外）で同様にページ内リンクをクリックし、従来と挙動が変わらないことを確認する
5. キーボード操作（Tabキー）でページ内リンクにフォーカスを移動し、フォーカス先の見出しが固定ヘッダーに隠れないことを確認する
6. `@media print` を想定し、印刷プレビュー（Cmd+P 等）で余白が不自然にズレていないことを確認する

### sticky ヘッダー（`header:has([class*="is-position-sticky"])`）の確認

前提: ヘッダーの位置設定を「sticky」にしておく。

1. 目次ブロックを設置したページをフロントで開き、ページ最上部（ヘッダーがまだ張り付いていない状態）で目次のリンクをクリックする
   → ジャンプ先の見出しの上端が、ヘッダー下端とほぼ隙間なく一致する位置で止まることを確認する
2. 一度スクロールしてヘッダーを画面上端に張り付かせた状態で、再度別の目次リンクをクリックする
   → 同様にヘッダーに隠れないことを確認する
3. 開発者ツールで `getComputedStyle(document.documentElement).getPropertyValue('--x-t9-fixed-header-height')` を確認し、sticky ヘッダーの実高さが反映されていることを確認する

### スクロールで出現するヘッダー（`*[class*="scrolled-header-fixed"]` / `is-style-scrolled-header-fixed`）の確認

前提: 当該ブロックスタイルを適用したヘッダーを設置し、目次ブロック等のページ内リンクを設置しておく。

1. ページ上部（`body` に `.header-fixed-active` が付いていない、ヘッダーが画面外に退避した状態）で目次のリンクをクリックする
   → ヘッダーが表示されていないため、ジャンプ先の見出しの上端付近に不要な余白（ゴーストスペース）が残らないことを確認する（`--x-t9-fixed-header-height` が `0px` に戻っていることを開発者ツールで確認する）
2. 一度スクロールしてヘッダーを画面内に出現させた（`.header-fixed-active` が付与された）状態で、再度目次のリンクをクリックする
   → ジャンプ先の見出しの上端が、出現したヘッダーの下端とほぼ隙間なく一致する位置で止まることを確認する
3. スクロールでヘッダーの出現・退避を繰り返し、`--x-t9-fixed-header-height` の値がヘッダーの表示状態に連動して切り替わる（表示時はヘッダー高さ、非表示時は `0px`）ことを確認する

### デグレ確認

- 固定ヘッダー・sticky ヘッダー・スクロールで出現するヘッダーのいずれも使用しないページで、ページ内リンクの挙動が変わっていないことを確認する
- Snow Monkey Forms連携（`plugin-support/snow-monkey-forms/js/smf-fixed-header-offset.js`）など、既存の固定ヘッダー関連機能に影響がないことを確認する
- 複数のヘッダーパターンが同時に存在するページ（通常は想定しない構成）で、意図しない極端な崩れがないことを確認する

## スクリーンショットについて

本PRの変更内容は「スクロール停止位置が数px変わる」という挙動の修正で、静止画では変化が分かりにくいため、上記確認手順の実測値（-15px 〜 -100px → 約-0.45px）で確認結果を記載しています（`org.review_assets_repo` 未設定のため画像埋め込みは省略）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 固定ヘッダー使用時、ページ内リンクの移動先やキーボードフォーカスがヘッダーに隠れる問題を修正しました。
  - ヘッダーの実際の高さに応じて、スクロール位置の補正がリアルタイムで調整されます。
  - 印刷時はスクロール補正を無効化し、適切に表示されるよう改善しました。

- **ドキュメント**
  - 上記の修正内容を変更履歴に追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
